### PR TITLE
fix(separator): restore torch.backends.cudnn.benchmark after inference

### DIFF
--- a/pymss/separator.py
+++ b/pymss/separator.py
@@ -748,6 +748,7 @@ class MSSeparator:
         self.device = _select_device(device, self.device_ids, self.logger)
         self.inference_params = _prefer_mlx_for_auto(device, self.device, self.inference_params, self.logger)
 
+        self._cudnn_benchmark_initial = torch.backends.cudnn.benchmark
         torch.backends.cudnn.benchmark = True
         self.logger.info(f"Using device: {self.device}, device_ids: {self.device_ids}")
 
@@ -1470,7 +1471,10 @@ class MSSeparator:
 
         Returns:
             None: Model references are dropped and CUDA/MPS/MLX caches are
-            cleared where available.
+            cleared where available. The ``torch.backends.cudnn.benchmark``
+            flag is also restored to the value it held before the separator
+            was initialized, so embedding pymss in a larger pipeline does not
+            leak the benchmark-enabled side effect into other modules.
 
         Example:
             >>> separator.close()"""
@@ -1492,10 +1496,30 @@ class MSSeparator:
                 except Exception as exc:
                     self.logger.debug(f"Could not move model to CPU during close: {exc}")
         finally:
+            self._restore_cudnn_benchmark()
             self.model = None
             self.config = None
             self.store_dirs = {}
             self.del_cache()
+
+    def _restore_cudnn_benchmark(self):
+        """Restore ``torch.backends.cudnn.benchmark`` to its pre-init value.
+
+        Args:
+            None: This callable does not accept user-provided arguments.
+
+        Returns:
+            None: When the separator captured an initial ``cudnn.benchmark``
+            value during initialization, the global flag is restored to that
+            value so downstream modules observe the same state as before
+            pymss ran."""
+        initial = getattr(self, "_cudnn_benchmark_initial", None)
+        if initial is None:
+            return
+        try:
+            torch.backends.cudnn.benchmark = initial
+        except Exception as exc:
+            self.logger.debug(f"Could not restore torch.backends.cudnn.benchmark: {exc}")
 
     def del_cache(self):
         """Run garbage collection and clear accelerator memory caches.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pymss"
-version = "2.0.6"
+version = "2.0.7"
 description = "Python package for music source separation."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"


### PR DESCRIPTION
## 问题

`MSSeparator.__init__` 中设置了 `torch.backends.cudnn.benchmark = True`，这是一个全局副作用。当 pymss 被集成进更大的流水线、与其他模块共享同一进程时，推理结束后该全局标志仍保持为 `True`，会影响其他模块的正常运行。

## 修复

- 在 `__init__` 中开启 `cudnn.benchmark` **之前**先捕获其初始值，保存到 `self._cudnn_benchmark_initial`。
- 在 `MSSeparator.close()` / `__exit__` 中调用新增的 `_restore_cudnn_benchmark()`，将全局标志**还原为初始值**（而非简单地设为 `False`），确保下游模块观察到 pymss 运行前的相同状态。
- `close()` 在 `finally` 块中调用还原逻辑，并在内部对异常做了兜底，保证即使还原失败也不会影响后续资源释放；多次调用 `close()` 幂等。

## 版本

patch 版本号 `2.0.6` -> `2.0.7`。

## 影响面

- 对独立使用 pymss 的用户无影响（推理期间行为不变）。
- 对嵌入式 / 集成场景：消除全局副作用，避免污染其他模块的 `cudnn.benchmark` 状态。
