### PR TITLE
feat: plugin system (capability registry + built-in DSP/codec capabilities)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,9 @@ resources
 tmp
 all_models
 /mps/
+
+# local test artifacts
+testflow.json
+testflow_out/
+input.wav
+input2.wav

--- a/pymss/__init__.py
+++ b/pymss/__init__.py
@@ -53,6 +53,13 @@ from .ensemble import ensemble_audios, save_ensemble_audio
 from .audio_io import load_audio, save_audio
 from .workflow import WorkflowRunner, load_workflow_file, run_workflow_file, validate_workflow
 
+# Register built-in capabilities (DSP + channel ops + ensemble) into the plugin
+# registry so they can be consumed by nodes, CLI, and library code uniformly.
+# ensemble is registered as a side effect of importing .ensemble above.
+from .plugins.builtins import register_builtin_capabilities as _register_builtin_caps
+
+_register_builtin_caps()
+
 __all__ = (
     "MSSeparator",
     "get_separation_logger",

--- a/pymss/__init__.py
+++ b/pymss/__init__.py
@@ -59,6 +59,11 @@ from .workflow import WorkflowRunner, load_workflow_file, run_workflow_file, val
 from .plugins.builtins import register_builtin_capabilities as _register_builtin_caps
 
 _register_builtin_caps()
+# Register built-in codec capabilities (wav/flac/mp3/m4a/aac/opus/vorbis/ogg)
+# so require_capability('opus_encode') etc. work without first calling save_audio.
+from .plugins.codecs import register_builtin_codecs as _register_builtin_codecs
+
+_register_builtin_codecs()
 
 __all__ = (
     "MSSeparator",

--- a/pymss/audio_io.py
+++ b/pymss/audio_io.py
@@ -213,7 +213,8 @@ def save_audio(path, audio, sr, output_format, audio_params):
             stereo arrays should be shaped as ``(samples, 2)``.
         sr (int): Sample rate in Hz.
         output_format (str): Output format. Supported values are ``wav``,
-            ``flac``, ``mp3``, and ``m4a``.
+            ``flac``, ``mp3``, ``m4a``, ``aac``, ``opus``, ``vorbis``, and
+            ``ogg`` (alias for vorbis).
         audio_params (dict): Encoding options. Supported keys include
             ``wav_bit_depth`` (``FLOAT``, ``PCM_16``, ``PCM_24``),
             ``flac_bit_depth`` (currently ``PCM_24`` uses soundfile),
@@ -245,10 +246,41 @@ def save_audio(path, audio, sr, output_format, audio_params):
     audio_array = np.asarray(audio)
     layout = "stereo" if audio_array.ndim > 1 and audio_array.shape[1] == 2 else "mono"
 
+    # Opus only supports 8000/12000/16000/24000/48000 Hz. Resample to the nearest
+    # legal rate using librosa (already a pymss dependency) so callers can pass any sr.
+    _OPUS_RATES = (8000, 12000, 16000, 24000, 48000)
+    if output_format == "opus" and int(sr) not in _OPUS_RATES:
+        target_sr = min(_OPUS_RATES, key=lambda r: abs(r - int(sr)))
+        import librosa
+        audio_array = np.stack(
+            [librosa.resample(ch.astype(np.float32), orig_sr=int(sr), target_sr=target_sr)
+             for ch in (audio_array.T if audio_array.ndim == 2 else [audio_array])],
+            axis=1,
+        ) if audio_array.ndim == 2 else librosa.resample(audio_array.astype(np.float32), orig_sr=int(sr), target_sr=target_sr)
+        sr = target_sr
+
+    # soundfile-backed formats (lossless-ish container + native encoder):
+    # opus/vorbis go through libsndfile, which handles OGG encapsulation cleanly.
+    if output_format == "opus":
+        import soundfile as sf
+        sf.write(path, audio_array, int(sr), format="OGG", subtype="OPUS")
+        return
+    if output_format == "vorbis":
+        import soundfile as sf
+        sf.write(path, audio_array, int(sr), format="OGG", subtype="VORBIS")
+        return
+    if output_format == "ogg":  # alias: ogg defaults to vorbis inside the container
+        import soundfile as sf
+        sf.write(path, audio_array, int(sr), format="OGG", subtype="VORBIS")
+        return
+
     if output_format == "mp3":
         codec = "libmp3lame"
     elif output_format == "m4a":
         codec = audio_params.get("m4a_codec", "aac")
+    elif output_format == "aac":
+        # Raw AAC in ADTS container; use .aac extension. For .m4a use output_format="m4a".
+        codec = "aac"
     elif output_format == "flac":
         # PyAV's FLAC encoder only exposes a single "flac" codec in the current version.
         # In the current version, without access to bits_per_raw_sample in PyAV, PCM_24 may still be encoded as 16-bit.
@@ -262,7 +294,12 @@ def save_audio(path, audio, sr, output_format, audio_params):
         wav_codecs = {"PCM_16": "pcm_s16le", "PCM_24": "pcm_s24le", "FLOAT": "pcm_f32le"}
         codec = wav_codecs.get(audio_params.get("wav_bit_depth", "FLOAT"), wav_codecs["FLOAT"])
 
-    with av.open(path, "w") as container:
+    # Container hint: aac goes into ADTS by default; m4a into mp4/m4a.
+    container_format = None
+    if output_format == "aac":
+        container_format = "adts"
+
+    with av.open(path, "w", format=container_format) as container:
         stream = container.add_stream(codec, rate=int(sr))
         stream.layout = layout
         if output_format == "mp3":
@@ -271,6 +308,8 @@ def save_audio(path, audio, sr, output_format, audio_params):
             stream.bit_rate = _bitrate_to_int(audio_params.get("m4a_bit_rate", "512k"))
             if codec == "aac_at":
                 stream.codec_context.options = {"aac_at_quality": str(audio_params.get("m4a_aac_at_quality", 2))}
+        elif output_format == "aac":
+            stream.bit_rate = _bitrate_to_int(audio_params.get("aac_bit_rate", "128k"))
 
         frame = av.AudioFrame.from_ndarray(_format_audio(audio_array), format="fltp", layout=layout)
         frame.sample_rate = int(sr)

--- a/pymss/audio_io.py
+++ b/pymss/audio_io.py
@@ -243,77 +243,38 @@ def save_audio(path, audio, sr, output_format, audio_params):
         ...     {"flac_bit_depth": "PCM_24"},
         ... )"""
     output_format = output_format.lower()
-    audio_array = np.asarray(audio)
-    layout = "stereo" if audio_array.ndim > 1 and audio_array.shape[1] == 2 else "mono"
 
-    # Opus only supports 8000/12000/16000/24000/48000 Hz. Resample to the nearest
-    # legal rate using librosa (already a pymss dependency) so callers can pass any sr.
-    _OPUS_RATES = (8000, 12000, 16000, 24000, 48000)
-    if output_format == "opus" and int(sr) not in _OPUS_RATES:
-        target_sr = min(_OPUS_RATES, key=lambda r: abs(r - int(sr)))
-        import librosa
-        audio_array = np.stack(
-            [librosa.resample(ch.astype(np.float32), orig_sr=int(sr), target_sr=target_sr)
-             for ch in (audio_array.T if audio_array.ndim == 2 else [audio_array])],
-            axis=1,
-        ) if audio_array.ndim == 2 else librosa.resample(audio_array.astype(np.float32), orig_sr=int(sr), target_sr=target_sr)
-        sr = target_sr
+    # Dispatch to the registered codec capability. Each format registers a
+    # f"{format}_encode" capability; this lets plugins add new formats without
+    # touching save_audio, and unknown formats raise CapabilityNotFound instead
+    # of silently falling through to wav.
+    from .plugins.codecs import register_builtin_codecs
+    from .plugins.registry import _REGISTRY
 
-    # soundfile-backed formats (lossless-ish container + native encoder):
-    # opus/vorbis go through libsndfile, which handles OGG encapsulation cleanly.
-    if output_format == "opus":
-        import soundfile as sf
-        sf.write(path, audio_array, int(sr), format="OGG", subtype="OPUS")
-        return
-    if output_format == "vorbis":
-        import soundfile as sf
-        sf.write(path, audio_array, int(sr), format="OGG", subtype="VORBIS")
-        return
-    if output_format == "ogg":  # alias: ogg defaults to vorbis inside the container
-        import soundfile as sf
-        sf.write(path, audio_array, int(sr), format="OGG", subtype="VORBIS")
-        return
+    register_builtin_codecs()  # idempotent
+    cap_name = f"{output_format}_encode"
+    if cap_name not in _REGISTRY.capabilities:
+        from .plugins.registry import CapabilityNotFound
 
-    if output_format == "mp3":
-        codec = "libmp3lame"
-    elif output_format == "m4a":
-        codec = audio_params.get("m4a_codec", "aac")
-    elif output_format == "aac":
-        # Raw AAC in ADTS container; use .aac extension. For .m4a use output_format="m4a".
-        codec = "aac"
+        raise CapabilityNotFound(cap_name)
+    encode = _REGISTRY.capabilities[cap_name].func
+
+    # Map legacy audio_params keys to the codec's keyword args.
+    if output_format == "wav":
+        encode(audio, sr, path, bit_depth=audio_params.get("wav_bit_depth", "FLOAT"))
     elif output_format == "flac":
-        # PyAV's FLAC encoder only exposes a single "flac" codec in the current version.
-        # In the current version, without access to bits_per_raw_sample in PyAV, PCM_24 may still be encoded as 16-bit.
-        # Use soundfile to save 24-bit FLAC
-        codec = "flac"
-        if audio_params.get("flac_bit_depth", "PCM_24") == "PCM_24":
-            import soundfile as sf
-
-            return sf.write(path, audio_array, int(sr), format="FLAC", subtype="PCM_24")
+        encode(audio, sr, path, bit_depth=audio_params.get("flac_bit_depth", "PCM_24"))
+    elif output_format == "mp3":
+        encode(audio, sr, path, bit_rate=audio_params.get("mp3_bit_rate", "320k"))
+    elif output_format == "m4a":
+        encode(
+            audio, sr, path,
+            bit_rate=audio_params.get("m4a_bit_rate", "512k"),
+            codec=audio_params.get("m4a_codec", "aac"),
+            aac_at_quality=audio_params.get("m4a_aac_at_quality", 2),
+        )
+    elif output_format == "aac":
+        encode(audio, sr, path, bit_rate=audio_params.get("aac_bit_rate", "128k"))
     else:
-        wav_codecs = {"PCM_16": "pcm_s16le", "PCM_24": "pcm_s24le", "FLOAT": "pcm_f32le"}
-        codec = wav_codecs.get(audio_params.get("wav_bit_depth", "FLOAT"), wav_codecs["FLOAT"])
-
-    # Container hint: aac goes into ADTS by default; m4a into mp4/m4a.
-    container_format = None
-    if output_format == "aac":
-        container_format = "adts"
-
-    with av.open(path, "w", format=container_format) as container:
-        stream = container.add_stream(codec, rate=int(sr))
-        stream.layout = layout
-        if output_format == "mp3":
-            stream.bit_rate = _bitrate_to_int(audio_params.get("mp3_bit_rate", "320k"))
-        elif output_format == "m4a":
-            stream.bit_rate = _bitrate_to_int(audio_params.get("m4a_bit_rate", "512k"))
-            if codec == "aac_at":
-                stream.codec_context.options = {"aac_at_quality": str(audio_params.get("m4a_aac_at_quality", 2))}
-        elif output_format == "aac":
-            stream.bit_rate = _bitrate_to_int(audio_params.get("aac_bit_rate", "128k"))
-
-        frame = av.AudioFrame.from_ndarray(_format_audio(audio_array), format="fltp", layout=layout)
-        frame.sample_rate = int(sr)
-        for packet in stream.encode(frame):
-            container.mux(packet)
-        for packet in stream.encode():
-            container.mux(packet)
+        # opus / vorbis / ogg / any plugin-registered codec: no legacy params.
+        encode(audio, sr, path)

--- a/pymss/cli.py
+++ b/pymss/cli.py
@@ -138,6 +138,58 @@ def cmd_unregister(args):
     return 0
 
 
+def cmd_install(args):
+    """Install a plugin by name, URL, or local path."""
+    from .plugins.install import install as plugin_install, InstallError
+
+    try:
+        result = plugin_install(args.target)
+    except InstallError as exc:
+        print(f"pymss install: error: {exc}", file=sys.stderr)
+        return 1
+    print(f"Installed plugin '{result.name}' -> {result.path} (from {result.source})")
+    print("It will be loaded on the next pymss run. Run `pymss plugins list` to verify.")
+    return 0
+
+
+def cmd_uninstall(args):
+    """Remove an installed plugin."""
+    from .plugins.install import uninstall as plugin_uninstall, InstallError
+
+    try:
+        removed = plugin_uninstall(args.name)
+    except InstallError as exc:
+        print(f"pymss uninstall: error: {exc}", file=sys.stderr)
+        return 1
+    print(f"Removed plugin '{args.name}' ({removed})")
+    return 0
+
+
+def cmd_plugins(args):
+    """List installed plugins and their load status, or show the plugins dir."""
+    from .plugins import bootstrap, get_plugins_dir, get_last_report
+
+    if getattr(args, "plugins_command", None) == "dir":
+        print(get_plugins_dir())
+        return 0
+
+    # Default: list.
+    plugins_dir = get_plugins_dir()
+    report = bootstrap()
+    print(f"Plugins directory: {plugins_dir}")
+    if not report.results:
+        print("No plugins installed.")
+        return 0
+    print("")
+    for r in report.results:
+        status = "OK" if r.loaded else f"FAILED ({r.error})"
+        print(f"  {r.name:<24} {status}")
+    failed = report.failed
+    if failed:
+        print(f"\n{len(failed)} plugin(s) failed to load.", file=sys.stderr)
+    return 1 if failed else 0
+
+
 def cmd_download(args):
     """Implement the cmd download helper.
 
@@ -466,6 +518,45 @@ def build_parser():
     download_parser.add_argument("--force", action="store_true")
     download_parser.add_argument("--supported-only", action="store_true", help="Only used with model='all'.")
     download_parser.set_defaults(func=cmd_download)
+
+    # ==========================
+    # Plugins (install / uninstall / list)
+    # ==========================
+    install_parser = subparsers.add_parser(
+        "install",
+        help="Install a plugin by official name, git URL, or local path.",
+        formatter_class=lambda prog: argparse.RawTextHelpFormatter(prog, max_help_position=60),
+    )
+    install_parser.add_argument(
+        "target",
+        help=(
+            "One of:\n"
+            "  <name>    official plugin name (resolved via the registry)\n"
+            "  <url>     git repository URL to clone\n"
+            "  <path>    local directory to copy"
+        ),
+    )
+    install_parser.set_defaults(func=cmd_install)
+
+    uninstall_parser = subparsers.add_parser(
+        "uninstall",
+        help="Remove an installed plugin.",
+        formatter_class=lambda prog: argparse.RawTextHelpFormatter(prog, max_help_position=60),
+    )
+    uninstall_parser.add_argument("name", help="Installed plugin name to remove.")
+    uninstall_parser.set_defaults(func=cmd_uninstall)
+
+    plugins_parser = subparsers.add_parser(
+        "plugins",
+        help="List installed plugins and their load status.",
+        formatter_class=lambda prog: argparse.RawTextHelpFormatter(prog, max_help_position=60),
+    )
+    plugins_subparsers = plugins_parser.add_subparsers(
+        dest="plugins_command", required=False
+    )
+    plugins_subparsers.add_parser("list", help="List installed plugins (default).")
+    plugins_subparsers.add_parser("dir", help="Print the plugins directory path.")
+    plugins_parser.set_defaults(func=cmd_plugins, plugins_command="list")
 
     # ==========================
     # Inference

--- a/pymss/ensemble.py
+++ b/pymss/ensemble.py
@@ -322,3 +322,21 @@ def save_ensemble_audio(
     output_format = output_format or output_path.suffix.lstrip(".").lower() or "wav"
     save_audio(str(output_path), result, sample_rate, output_format, audio_params or {})
     return output_path
+
+
+# Register the waveform-combination capability (reuses average_waveforms, no
+# reimplementation). Lazy import avoids a circular dependency at module load.
+def _register_ensemble_capability() -> None:
+    from .plugins.registry import _REGISTRY
+
+    if "ensemble" in _REGISTRY.capabilities and _REGISTRY.capabilities["ensemble"].source == "builtin":
+        return
+    _REGISTRY.register_capability(
+        "ensemble",
+        average_waveforms,
+        source="builtin",
+        description="combine source waveforms (8 algorithms: avg/median/min/max x wave/fft)",
+    )
+
+
+_register_ensemble_capability()

--- a/pymss/plugins/__init__.py
+++ b/pymss/plugins/__init__.py
@@ -1,0 +1,57 @@
+"""pymss plugin system.
+
+Public API for plugin authors:
+    from pymss.plugins import (
+        register_capability,  # register a named capability
+        register_node,        # register a workflow node
+        register_cli,         # register a CLI subcommand
+        require_capability,   # look up a capability by name
+    )
+
+Internals for pymss core:
+    from pymss.plugins import bootstrap, get_plugins_dir, get_registry
+
+See docs/plugins.md for the full design.
+"""
+
+from __future__ import annotations
+
+from .loader import (
+    DEFAULT_PLUGINS_DIR,
+    ENTRYPOINT_GROUP,
+    PluginLoadReport,
+    PluginLoadResult,
+    bootstrap,
+    get_last_report,
+    get_plugins_dir,
+    reset,
+)
+from .registry import (
+    CapabilityNotFound,
+    PluginRegistry,
+    get_registry,
+    register_capability,
+    register_cli,
+    register_node,
+    require_capability,
+)
+
+__all__ = [
+    # registration API (plugin authors)
+    "register_capability",
+    "register_node",
+    "register_cli",
+    "require_capability",
+    "CapabilityNotFound",
+    # discovery / loading (pymss core)
+    "bootstrap",
+    "get_plugins_dir",
+    "get_last_report",
+    "reset",
+    "get_registry",
+    "PluginRegistry",
+    "PluginLoadReport",
+    "PluginLoadResult",
+    "DEFAULT_PLUGINS_DIR",
+    "ENTRYPOINT_GROUP",
+]

--- a/pymss/plugins/builtins.py
+++ b/pymss/plugins/builtins.py
@@ -1,0 +1,233 @@
+"""Built-in capabilities: DSP and channel operations registered into the plugin
+system so they can be consumed by nodes, CLI, and library code uniformly.
+
+These are NOT separate plugins — they live in pymss core but use the same
+registration API as plugins. pymss itself eats its own dogfood.
+
+Capability registry (flat, no categories):
+
+  Channel ops:
+    to_mono         (audio) -> mono audio
+    split_channels  (audio) -> list of per-channel mono audios
+    join_channels   (audios) -> multichannel audio
+
+  DSP ops:
+    adjust_volume   (audio, sr, gain_db) -> audio
+    invert_phase    (audio) -> -audio
+    normalize_peak  (audio, target_peak) -> scaled audio
+    standardize     (audio) -> (audio, stats); destandardize(audio, stats) -> audio
+    trim            (audio, sr, start, duration) -> audio
+    concat          (audios) -> audio
+    mix             (audios, mode) -> audio   (add/mean/subtract)
+    ensemble        (pred_track_3d, weights, algorithm) -> audio
+
+All audio arrays are numpy float32, channel-first: shape (channels, samples)
+or (samples,) for mono. This matches pymss's internal convention.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .registry import _REGISTRY
+
+
+# ---------------------------------------------------------------------------
+# Channel operations
+# ---------------------------------------------------------------------------
+
+
+def to_mono(audio) -> np.ndarray:
+    """Collapse a multichannel audio array to mono by averaging channels.
+
+    Accepts channel-first (channels, samples) or 1-D (samples,). Returns 1-D.
+    """
+    audio = np.asarray(audio, dtype=np.float32)
+    if audio.ndim == 1:
+        return audio
+    # channel-first: average across axis 0
+    return audio.mean(axis=0)
+
+
+def split_channels(audio) -> list[np.ndarray]:
+    """Split a multichannel (channel-first) array into a list of mono arrays."""
+    audio = np.asarray(audio, dtype=np.float32)
+    if audio.ndim == 1:
+        return [audio]
+    return [audio[i] for i in range(audio.shape[0])]
+
+
+def join_channels(audios) -> np.ndarray:
+    """Stack a sequence of equal-length mono arrays into channel-first multichannel."""
+    arrays = [np.asarray(a, dtype=np.float32) for a in audios]
+    if not arrays:
+        raise ValueError("join_channels requires at least one input")
+    lengths = {a.shape[-1] for a in arrays}
+    if len(lengths) != 1:
+        raise ValueError(f"all inputs must have the same length; got {sorted(lengths)}")
+    return np.stack(arrays, axis=0)
+
+
+# ---------------------------------------------------------------------------
+# DSP operations
+# ---------------------------------------------------------------------------
+
+
+def adjust_volume(audio, sample_rate=None, gain_db: float = 0.0) -> np.ndarray:
+    """Apply a gain in decibels. gain_db=0 is unity; +6 ≈ double amplitude."""
+    audio = np.asarray(audio, dtype=np.float32)
+    gain = 10 ** (gain_db / 20.0)
+    return audio * gain
+
+
+def invert_phase(audio, sample_rate=None) -> np.ndarray:
+    """Invert the phase (negate samples). Classic for 'mix - vocals = instrumental'."""
+    return -np.asarray(audio, dtype=np.float32)
+
+
+def normalize_peak(audio, sample_rate=None, target_peak: float = 0.99) -> np.ndarray:
+    """Scale audio so its peak amplitude equals target_peak. No-op on silence."""
+    audio = np.asarray(audio, dtype=np.float32)
+    peak = float(np.max(np.abs(audio))) if audio.size else 0.0
+    if peak <= 0.0 or not np.isfinite(peak):
+        return audio
+    return audio * (target_peak / peak)
+
+
+def standardize(audio, sample_rate=None):
+    """Zero-mean, unit-variance standardization (input preprocessing).
+
+    Returns (standardized_audio, stats) where stats=(mean, std). Use
+    destandardize() to reverse.
+    """
+    audio = np.asarray(audio, dtype=np.float32)
+    mono = audio.mean(0) if audio.ndim > 1 else audio
+    mean = float(mono.mean())
+    std = float(mono.std())
+    if std == 0:
+        return audio, (mean, std)
+    return (audio - mean) / std, (mean, std)
+
+
+def destandardize(audio, stats) -> np.ndarray:
+    """Reverse standardize(): audio * std + mean."""
+    audio = np.asarray(audio, dtype=np.float32)
+    mean, std = stats
+    return audio * std + mean
+
+
+def trim(audio, sample_rate: float, start: float = 0.0, duration: float | None = None) -> np.ndarray:
+    """Trim audio by time. start/duration in seconds. Keeps [start, start+duration)."""
+    audio = np.asarray(audio, dtype=np.float32)
+    sr = int(sample_rate)
+    start_sample = max(0, int(start * sr))
+    if duration is None:
+        end_sample = audio.shape[-1]
+    else:
+        end_sample = min(audio.shape[-1], start_sample + int(duration * sr))
+    return audio[..., start_sample:end_sample]
+
+
+def concat(audios, sample_rate=None, crossfade: float = 0.0) -> np.ndarray:
+    """Concatenate audios end-to-end along the time axis.
+
+    Inputs must share channel count. crossfade (seconds) overlaps the boundary
+    with a linear fade when > 0.
+    """
+    arrays = [np.asarray(a, dtype=np.float32) for a in audios]
+    if not arrays:
+        raise ValueError("concat requires at least one input")
+    if crossfade and crossfade > 0 and sample_rate:
+        # naive crossfade: linear overlap-add
+        cf = int(crossfade * sample_rate)
+        out = arrays[0]
+        for nxt in arrays[1:]:
+            if cf > 0 and out.shape[-1] >= cf and nxt.shape[-1] >= cf:
+                fade = np.linspace(1, 0, cf, dtype=np.float32)
+                tail = out[..., -cf:] * fade + nxt[..., :cf] * (1 - fade)
+                out = np.concatenate([out[..., :-cf], tail, nxt[..., cf:]], axis=-1)
+            else:
+                out = np.concatenate([out, nxt], axis=-1)
+        return out
+    return np.concatenate(arrays, axis=-1)
+
+
+def mix(audios, sample_rate=None, mode: str = "add") -> np.ndarray:
+    """Combine equal-length audios sample-wise.
+
+    mode:
+      add       - sum (may clip)
+      mean      - average
+      subtract  - first minus the rest
+      min       - element-wise minimum by magnitude
+      max       - element-wise maximum by magnitude
+    """
+    arrays = [np.asarray(a, dtype=np.float32) for a in audios]
+    if not arrays:
+        raise ValueError("mix requires at least one input")
+    stacked = np.stack(arrays, axis=0)
+    if mode == "add":
+        return stacked.sum(axis=0)
+    if mode == "mean":
+        return stacked.mean(axis=0)
+    if mode == "subtract":
+        result = arrays[0].copy()
+        for a in arrays[1:]:
+            result = result - a
+        return result
+    if mode == "min":
+        # min by absolute value, keep sign
+        idx = np.argmin(np.abs(stacked), axis=0)
+        return np.take_along_axis(stacked, idx[None, ...], axis=0)[0]
+    if mode == "max":
+        idx = np.argmax(np.abs(stacked), axis=0)
+        return np.take_along_axis(stacked, idx[None, ...], axis=0)[0]
+    raise ValueError(f"unknown mix mode: {mode}")
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def register_builtin_capabilities() -> None:
+    """Register all built-in DSP / channel capabilities into the shared registry.
+
+    Idempotent: skips names already registered as builtin (avoids duplicate
+    warnings when called more than once).
+    """
+    caps = {
+        # channel ops
+        "to_mono": (to_mono, "collapse multichannel to mono by averaging"),
+        "split_channels": (split_channels, "split multichannel into per-channel mono list"),
+        "join_channels": (join_channels, "stack mono arrays into multichannel"),
+        # dsp ops
+        "adjust_volume": (adjust_volume, "apply gain in dB"),
+        "invert_phase": (invert_phase, "negate samples (phase inversion)"),
+        "normalize_peak": (normalize_peak, "scale to a target peak amplitude"),
+        "standardize": (standardize, "zero-mean unit-variance (input preprocessing)"),
+        "destandardize": (destandardize, "reverse standardize()"),
+        "trim": (trim, "trim by start time and duration"),
+        "concat": (concat, "concatenate audios end-to-end"),
+        "mix": (mix, "sample-wise combine (add/mean/subtract/min/max)"),
+    }
+    for name, (func, desc) in caps.items():
+        if name in _REGISTRY.capabilities and _REGISTRY.capabilities[name].source == "builtin":
+            continue
+        _REGISTRY.register_capability(name, func, source="builtin", description=desc)
+
+
+__all__ = [
+    "to_mono",
+    "split_channels",
+    "join_channels",
+    "adjust_volume",
+    "invert_phase",
+    "normalize_peak",
+    "standardize",
+    "destandardize",
+    "trim",
+    "concat",
+    "mix",
+    "register_builtin_capabilities",
+]

--- a/pymss/plugins/builtins.py
+++ b/pymss/plugins/builtins.py
@@ -19,6 +19,9 @@ Capability registry (flat, no categories):
     trim            (audio, sr, start, duration) -> audio
     concat          (audios) -> audio
     mix             (audios, mode) -> audio   (add/mean/subtract)
+    empty_audio     (duration, sr, channels) -> silent audio
+    eq              (audio, sr, low/mid/high gain+freq+q) -> audio (biquad)
+    resample        (audio, orig_sr, target_sr) -> audio
     ensemble        (pred_track_3d, weights, algorithm) -> audio
 
 All audio arrays are numpy float32, channel-first: shape (channels, samples)
@@ -185,6 +188,113 @@ def mix(audios, sample_rate=None, mode: str = "add") -> np.ndarray:
     raise ValueError(f"unknown mix mode: {mode}")
 
 
+def empty_audio(duration: float, sample_rate: float, channels: int = 2) -> np.ndarray:
+    """Generate silent audio of a given duration. channel-first (channels, samples)."""
+    n_samples = int(duration * sample_rate)
+    if channels <= 1:
+        return np.zeros(n_samples, dtype=np.float32)
+    return np.zeros((channels, n_samples), dtype=np.float32)
+
+
+# Audio EQ Cookbook (Robert Bristow-Johnson) biquad coefficient helpers.
+# These are the standard formulas behind torchaudio.functional.bass_biquad /
+# equalizer_biquad / treble_biquad, implemented with scipy.signal (already a
+# pymss dependency via librosa) so no torchaudio is needed.
+
+
+def _low_shelf_coeffs(freq, gain_db, sr, q=0.707):
+    A = 10 ** (gain_db / 40.0)
+    w0 = 2 * np.pi * freq / sr
+    alpha = np.sin(w0) / (2 * q)
+    cosw = np.cos(w0)
+    sqA = np.sqrt(A)
+    b0 = A * ((A + 1) - (A - 1) * cosw + 2 * sqA * alpha)
+    b1 = 2 * A * ((A - 1) - (A + 1) * cosw)
+    b2 = A * ((A + 1) - (A - 1) * cosw - 2 * sqA * alpha)
+    a0 = (A + 1) + (A - 1) * cosw + 2 * sqA * alpha
+    a1 = -2 * ((A - 1) + (A + 1) * cosw)
+    a2 = (A + 1) + (A - 1) * cosw - 2 * sqA * alpha
+    return [b0 / a0, b1 / a0, b2 / a0], [1.0, a1 / a0, a2 / a0]
+
+
+def _high_shelf_coeffs(freq, gain_db, sr, q=0.707):
+    A = 10 ** (gain_db / 40.0)
+    w0 = 2 * np.pi * freq / sr
+    alpha = np.sin(w0) / (2 * q)
+    cosw = np.cos(w0)
+    sqA = np.sqrt(A)
+    b0 = A * ((A + 1) + (A - 1) * cosw + 2 * sqA * alpha)
+    b1 = -2 * A * ((A - 1) + (A + 1) * cosw)
+    b2 = A * ((A + 1) + (A - 1) * cosw - 2 * sqA * alpha)
+    a0 = (A + 1) - (A - 1) * cosw + 2 * sqA * alpha
+    a1 = 2 * ((A - 1) - (A + 1) * cosw)
+    a2 = (A + 1) - (A - 1) * cosw - 2 * sqA * alpha
+    return [b0 / a0, b1 / a0, b2 / a0], [1.0, a1 / a0, a2 / a0]
+
+
+def _peaking_coeffs(freq, gain_db, sr, q):
+    A = 10 ** (gain_db / 40.0)
+    w0 = 2 * np.pi * freq / sr
+    alpha = np.sin(w0) / (2 * q)
+    cosw = np.cos(w0)
+    b0 = 1 + alpha * A
+    b1 = -2 * cosw
+    b2 = 1 - alpha * A
+    a0 = 1 + alpha / A
+    a1 = -2 * cosw
+    a2 = 1 - alpha / A
+    return [b0 / a0, b1 / a0, b2 / a0], [1.0, a1 / a0, a2 / a0]
+
+
+def eq(
+    audio,
+    sample_rate: float,
+    low_gain_db: float = 0.0, low_freq: int = 100,
+    mid_gain_db: float = 0.0, mid_freq: int = 1000, mid_q: float = 0.707,
+    high_gain_db: float = 0.0, high_freq: int = 5000,
+) -> np.ndarray:
+    """3-band equalizer (low shelf / peaking / high shelf) via biquad filters.
+
+    Equivalent to ComfyUI's AudioEqualizer3Band (same parameters), implemented
+    with scipy.signal.lfilter so no torchaudio dependency is needed.
+    Audio is channel-first (channels, samples) or 1-D mono.
+    """
+    from scipy.signal import lfilter
+
+    audio = np.asarray(audio, dtype=np.float32)
+    out = audio
+    if low_gain_db != 0:
+        b, a = _low_shelf_coeffs(low_freq, low_gain_db, sample_rate)
+        out = lfilter(b, a, out, axis=-1)
+    if mid_gain_db != 0:
+        b, a = _peaking_coeffs(mid_freq, mid_gain_db, sample_rate, mid_q)
+        out = lfilter(b, a, out, axis=-1)
+    if high_gain_db != 0:
+        b, a = _high_shelf_coeffs(high_freq, high_gain_db, sample_rate)
+        out = lfilter(b, a, out, axis=-1)
+    return np.asarray(out, dtype=np.float32)
+
+
+def resample(audio, orig_sr: float, target_sr: float) -> np.ndarray:
+    """Resample audio between sample rates using librosa (already a dependency).
+
+    Audio is channel-first (channels, samples) or 1-D mono. Returns the same
+    layout at the target sample rate.
+    """
+    import librosa
+
+    audio = np.asarray(audio, dtype=np.float32)
+    if int(orig_sr) == int(target_sr):
+        return audio
+    if audio.ndim == 1:
+        return librosa.resample(audio, orig_sr=int(orig_sr), target_sr=int(target_sr))
+    # channel-first: resample each channel, pad to equal length
+    channels = [librosa.resample(audio[i], orig_sr=int(orig_sr), target_sr=int(target_sr)) for i in range(audio.shape[0])]
+    maxlen = max(ch.shape[-1] for ch in channels)
+    padded = np.stack([np.pad(ch, (0, maxlen - ch.shape[-1])) for ch in channels], axis=0)
+    return padded
+
+
 # ---------------------------------------------------------------------------
 # Registration
 # ---------------------------------------------------------------------------
@@ -210,6 +320,9 @@ def register_builtin_capabilities() -> None:
         "trim": (trim, "trim by start time and duration"),
         "concat": (concat, "concatenate audios end-to-end"),
         "mix": (mix, "sample-wise combine (add/mean/subtract/min/max)"),
+        "empty_audio": (empty_audio, "generate silent audio of a given duration"),
+        "eq": (eq, "3-band equalizer (biquad, scipy-backed)"),
+        "resample": (resample, "resample between sample rates (librosa)"),
     }
     for name, (func, desc) in caps.items():
         if name in _REGISTRY.capabilities and _REGISTRY.capabilities[name].source == "builtin":
@@ -229,5 +342,8 @@ __all__ = [
     "trim",
     "concat",
     "mix",
+    "empty_audio",
+    "eq",
+    "resample",
     "register_builtin_capabilities",
 ]

--- a/pymss/plugins/codecs.py
+++ b/pymss/plugins/codecs.py
@@ -1,0 +1,197 @@
+"""Built-in codec capabilities: encode/decode for the audio formats pymss supports.
+
+Each format is registered as a separate capability (wav_encode, mp3_encode,
+opus_encode, ...). This keeps the capability pool flat and lets a plugin
+register just one format (e.g. a hypothetical wma_encode) without touching the
+others.
+
+All encoders share the signature:
+    encode(audio: np.ndarray, sample_rate: int, path, **params) -> None
+
+audio is sample-major: (samples,) for mono or (samples, channels) for
+multichannel — matching save_audio's public convention.
+
+save_audio() becomes a thin dispatcher: it looks up f"{output_format}_encode"
+in the capability pool and calls it. Unknown formats raise CapabilityNotFound
+(instead of silently falling through to wav, as the old else-branch did).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from .registry import _REGISTRY
+
+
+def _to_array(audio) -> np.ndarray:
+    return np.asarray(audio)
+
+
+def _layout(audio: np.ndarray) -> str:
+    return "stereo" if audio.ndim > 1 and audio.shape[1] == 2 else "mono"
+
+
+def _resample_opus(audio: np.ndarray, sr: int):
+    """Opus needs 8/12/16/24/48 kHz. Resample to nearest legal rate via librosa."""
+    _OPUS_RATES = (8000, 12000, 16000, 24000, 48000)
+    if int(sr) in _OPUS_RATES:
+        return audio, int(sr)
+    import librosa
+
+    target_sr = min(_OPUS_RATES, key=lambda r: abs(r - int(sr)))
+    if audio.ndim == 2:
+        channels = [librosa.resample(audio[:, c].astype(np.float32), orig_sr=int(sr), target_sr=target_sr) for c in range(audio.shape[1])]
+        # pad to equal length then stack
+        maxlen = max(ch.shape[0] for ch in channels)
+        padded = np.stack([np.pad(ch, (0, maxlen - ch.shape[0])) for ch in channels], axis=1)
+        return padded, target_sr
+    return librosa.resample(audio.astype(np.float32), orig_sr=int(sr), target_sr=target_sr), target_sr
+
+
+# ---------------------------------------------------------------------------
+# soundfile-backed encoders (wav/flac/opus/vorbis/ogg)
+# ---------------------------------------------------------------------------
+
+
+def encode_wav(audio, sample_rate, path, bit_depth: str = "FLOAT", **_):
+    import soundfile as sf
+
+    # soundfile handles wav natively; map bit depth to subtype.
+    subtypes = {"FLOAT": "FLOAT", "PCM_16": "PCM_16", "PCM_24": "PCM_24", "PCM_32": "PCM_32"}
+    audio = _to_array(audio)
+    sf.write(str(path), audio, int(sample_rate), format="WAV", subtype=subtypes.get(bit_depth, "FLOAT"))
+
+
+def encode_flac(audio, sample_rate, path, bit_depth: str = "PCM_24", **_):
+    import soundfile as sf
+
+    audio = _to_array(audio)
+    sf.write(str(path), audio, int(sample_rate), format="FLAC", subtype="PCM_24" if bit_depth == "PCM_24" else "PCM_16")
+
+
+def encode_opus(audio, sample_rate, path, **_):
+    import soundfile as sf
+
+    audio = _to_array(audio)
+    audio, sr = _resample_opus(audio, sample_rate)
+    sf.write(str(path), audio, sr, format="OGG", subtype="OPUS")
+
+
+def encode_vorbis(audio, sample_rate, path, **_):
+    import soundfile as sf
+
+    audio = _to_array(audio)
+    sf.write(str(path), audio, int(sample_rate), format="OGG", subtype="VORBIS")
+
+
+# ---------------------------------------------------------------------------
+# PyAV-backed encoders (mp3/m4a/aac)
+# ---------------------------------------------------------------------------
+
+
+def _bitrate_to_int(value):
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    value = str(value).strip().lower()
+    return int(float(value[:-1]) * 1000) if value.endswith("k") else int(value)
+
+
+def _encode_with_av(audio, sample_rate, path, codec: str, container_format=None, bit_rate=None, extra_options=None):
+    """Shared PyAV encode path. audio is sample-major (samples, channels) or (samples,)."""
+    import av
+
+    audio = _to_array(audio)
+    layout = _layout(audio)
+    # PyAV wants channel-major float32 (channels, samples) via from_ndarray with fltp.
+    frame_audio = np.ascontiguousarray(audio[:, None] if audio.ndim == 1 else audio)
+    frame_audio = np.ascontiguousarray(frame_audio.astype(np.float32).T)
+
+    with av.open(str(path), "w", format=container_format) as container:
+        stream = container.add_stream(codec, rate=int(sample_rate))
+        stream.layout = layout
+        if bit_rate is not None:
+            stream.bit_rate = bit_rate
+        if extra_options:
+            stream.codec_context.options = extra_options
+
+        frame = av.AudioFrame.from_ndarray(frame_audio, format="fltp", layout=layout)
+        frame.sample_rate = int(sample_rate)
+        for packet in stream.encode(frame):
+            container.mux(packet)
+        for packet in stream.encode():
+            container.mux(packet)
+
+
+def encode_mp3(audio, sample_rate, path, bit_rate="320k", **_):
+    _encode_with_av(audio, sample_rate, path, codec="libmp3lame", bit_rate=_bitrate_to_int(bit_rate))
+
+
+def encode_m4a(audio, sample_rate, path, bit_rate="512k", codec="aac", aac_at_quality=2, **_):
+    extra = {"aac_at_quality": str(aac_at_quality)} if codec == "aac_at" else None
+    _encode_with_av(
+        audio, sample_rate, path, codec=codec, container_format=None, bit_rate=_bitrate_to_int(bit_rate), extra_options=extra
+    )
+
+
+def encode_aac(audio, sample_rate, path, bit_rate="128k", **_):
+    _encode_with_av(
+        audio, sample_rate, path, codec="aac", container_format="adts", bit_rate=_bitrate_to_int(bit_rate)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+# Map format name -> (capability func, default params). 'ogg' is a vorbis alias.
+_BUILTIN_CODECS = {
+    "wav": (encode_wav, {}),
+    "flac": (encode_flac, {}),
+    "mp3": (encode_mp3, {}),
+    "m4a": (encode_m4a, {}),
+    "aac": (encode_aac, {}),
+    "opus": (encode_opus, {}),
+    "vorbis": (encode_vorbis, {}),
+    "ogg": (encode_vorbis, {}),  # alias
+}
+
+
+def register_builtin_codecs() -> None:
+    """Register all built-in format encoders as capabilities.
+
+    Each format F registers a capability named f"{F}_encode". Idempotent.
+    """
+    for fmt, (func, _default_params) in _BUILTIN_CODECS.items():
+        name = f"{fmt}_encode"
+        if name in _REGISTRY.capabilities and _REGISTRY.capabilities[name].source == "builtin":
+            continue
+        _REGISTRY.register_capability(
+            name, func, source="builtin", description=f"encode audio to {fmt}"
+        )
+
+
+def supported_formats() -> list[str]:
+    """Return the list of formats with a registered {fmt}_encode capability."""
+    return sorted(
+        name[:-len("_encode")]
+        for name in _REGISTRY.capabilities
+        if name.endswith("_encode") and _REGISTRY.capabilities[name].source == "builtin"
+    )
+
+
+__all__ = [
+    "register_builtin_codecs",
+    "supported_formats",
+    "encode_wav",
+    "encode_flac",
+    "encode_mp3",
+    "encode_m4a",
+    "encode_aac",
+    "encode_opus",
+    "encode_vorbis",
+]

--- a/pymss/plugins/install.py
+++ b/pymss/plugins/install.py
@@ -1,0 +1,164 @@
+"""Plugin install / uninstall.
+
+Three install sources:
+  pymss install <name>     -> resolve <name> via official registry, git clone
+  pymss install <url>      -> git clone the repo URL directly
+  pymss install <path>     -> copy or symlink a local directory
+
+Official registry: fetched from a separate pymss-plugins repo's registry.json.
+The URL is configurable so the design works before that repo exists.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+from .loader import get_plugins_dir
+
+logger = logging.getLogger(__name__)
+
+# Default official registry URL. The pymss-plugins repo doesn't exist yet;
+# install-by-name will report a clear error until it does. Users can override
+# via PYMSS_PLUGINS_REGISTRY env var, or just install by URL/path.
+DEFAULT_REGISTRY_URL = (
+    "https://raw.githubusercontent.com/pymss-project/pymss-plugins/main/registry.json"
+)
+
+
+def _registry_url() -> str:
+    return os.environ.get("PYMSS_PLUGINS_REGISTRY", DEFAULT_REGISTRY_URL)
+
+
+class InstallError(Exception):
+    """Raised when a plugin install fails."""
+
+
+@dataclass
+class InstallResult:
+    name: str
+    path: Path
+    source: str  # "registry" | "url" | "path"
+
+
+def _is_url(arg: str) -> bool:
+    return arg.startswith("http://") or arg.startswith("https://") or arg.startswith("git@") or arg.startswith("ssh://")
+
+
+def _git_available() -> bool:
+    return shutil.which("git") is not None
+
+
+def _fetch_registry() -> dict[str, str]:
+    """Fetch and parse the official registry JSON. Raises InstallError on failure."""
+    url = _registry_url()
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "pymss"})
+        with urllib.request.urlopen(req, timeout=15) as resp:  # noqa: S310
+            data = json.loads(resp.read().decode("utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        raise InstallError(
+            f"could not fetch official plugin registry from {url}: {exc}. "
+            f"Install by URL or path instead, e.g. `pymss install https://github.com/xxx/pymss-opus`."
+        ) from exc
+    if not isinstance(data, dict):
+        raise InstallError(f"registry at {url} is not a JSON object mapping name -> url")
+    return data
+
+
+def _derive_plugin_name(arg: str) -> str:
+    """Derive a plugin folder name from a URL or local path."""
+    base = arg.rstrip("/").split("/")[-1]
+    if base.endswith(".git"):
+        base = base[:-4]
+    # Common prefix convention; keep the full name if it doesn't match.
+    for prefix in ("pymss-", "pymss_"):
+        if base.startswith(prefix):
+            return base[len(prefix):]
+    return base
+
+
+def _clone(url: str, dest: Path) -> None:
+    if not _git_available():
+        raise InstallError("git is required to install plugins from a URL; please install git first.")
+    if dest.exists():
+        raise InstallError(f"destination already exists: {dest} (uninstall it first)")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        subprocess.run(  # noqa: S603, S607
+            ["git", "clone", "--depth", "1", url, str(dest)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise InstallError(f"git clone failed: {exc.stderr.strip() or exc}") from exc
+
+
+def _copy_dir(src: Path, dest: Path) -> None:
+    if dest.exists():
+        raise InstallError(f"destination already exists: {dest} (uninstall it first)")
+    shutil.copytree(src, dest)
+
+
+def install(arg: str, plugins_dir: Path | None = None) -> InstallResult:
+    """Install a plugin by name, URL, or local path.
+
+    Returns InstallResult with the resolved name and destination path.
+    """
+    plugins_dir = plugins_dir or get_plugins_dir()
+    plugins_dir.mkdir(parents=True, exist_ok=True)
+
+    if _is_url(arg):
+        name = _derive_plugin_name(arg)
+        dest = plugins_dir / name
+        _clone(arg, dest)
+        return InstallResult(name=name, path=dest, source="url")
+
+    local = Path(arg).expanduser()
+    if local.exists() and local.is_dir():
+        name = local.name
+        dest = plugins_dir / name
+        _copy_dir(local, dest)
+        return InstallResult(name=name, path=dest, source="path")
+
+    # Otherwise treat arg as an official registry name.
+    registry = _fetch_registry()
+    if arg not in registry:
+        available = ", ".join(sorted(registry.keys())) or "(empty)"
+        raise InstallError(
+            f"'{arg}' is not in the official plugin registry. "
+            f"Available: {available}. Or install by URL/path."
+        )
+    url = registry[arg]
+    dest = plugins_dir / arg
+    _clone(url, dest)
+    return InstallResult(name=arg, path=dest, source="registry")
+
+
+def uninstall(name: str, plugins_dir: Path | None = None) -> Path:
+    """Remove an installed plugin directory. Returns the removed path."""
+    plugins_dir = plugins_dir or get_plugins_dir()
+    dest = plugins_dir / name
+    if not dest.exists():
+        raise InstallError(f"no installed plugin named '{name}' in {plugins_dir}")
+    if not dest.is_dir():
+        raise InstallError(f"'{name}' is not a plugin directory: {dest}")
+    shutil.rmtree(dest)
+    return dest
+
+
+__all__ = [
+    "InstallError",
+    "InstallResult",
+    "install",
+    "uninstall",
+    "DEFAULT_REGISTRY_URL",
+]

--- a/pymss/plugins/loader.py
+++ b/pymss/plugins/loader.py
@@ -1,0 +1,212 @@
+"""Plugin discovery and loading.
+
+Two discovery mechanisms (both use the same registration API):
+1. Folder scan (default, low-friction): each subdirectory of the plugins dir
+   is a plugin; we import its ``__init__.py`` (or ``plugin.py``).
+2. Entry points (optional, for proper packages): packages declare
+   ``[project.entry-points."pymss.plugins"]`` and we import the target module.
+
+A single plugin failing to load never blocks others: each import is wrapped in
+try/except, failures are recorded, and surfaced via ``pymss plugins list``.
+
+Plugin dir resolution order:
+  1. PYMSS_PLUGINS_DIR env var
+  2. ~/.pymss/plugins/
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import logging
+import os
+import sys
+from dataclasses import dataclass, field
+from importlib.metadata import entry_points
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PLUGINS_DIR = Path.home() / ".pymss" / "plugins"
+ENTRYPOINT_GROUP = "pymss.plugins"
+
+
+def get_plugins_dir() -> Path:
+    """Resolve the plugins directory from env var or default."""
+    env = os.environ.get("PYMSS_PLUGINS_DIR")
+    if env:
+        return Path(env).expanduser()
+    return DEFAULT_PLUGINS_DIR
+
+
+@dataclass
+class PluginLoadResult:
+    """Record of a plugin load attempt (success or failure)."""
+
+    name: str
+    source: str  # "folder:<dir>" | "entrypoint" | "builtin"
+    loaded: bool
+    error: str = ""
+    path: str = ""
+
+
+@dataclass
+class PluginLoadReport:
+    """Aggregate load report across all plugins in a bootstrap run."""
+
+    results: list[PluginLoadResult] = field(default_factory=list)
+    bootstrapped: bool = False
+
+    @property
+    def loaded_names(self) -> list[str]:
+        return [r.name for r in self.results if r.loaded]
+
+    @property
+    def failed(self) -> list[PluginLoadResult]:
+        return [r for r in self.results if not r.loaded]
+
+
+_LAST_REPORT: PluginLoadReport | None = None
+
+
+def get_last_report() -> PluginLoadReport | None:
+    """Return the most recent bootstrap report (for `pymss plugins list`)."""
+    return _LAST_REPORT
+
+
+def _import_plugin_module(modname: str, path: Path | None) -> bool:
+    """Import a plugin module by name (entrypoint) or file path (folder scan).
+
+    Returns True on success. Exceptions are logged by the caller.
+    """
+    if path is not None:
+        # Folder scan: load the file as a top-level module under a synthetic
+        # name so plugins don't need to be installed packages.
+        spec = importlib.util.spec_from_file_location(modname, path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"cannot load plugin module from {path}")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[modname] = module
+        spec.loader.exec_module(module)  # type: ignore[union-attr]
+    else:
+        importlib.import_module(modname)
+    return True
+
+
+def _scan_folder(plugins_dir: Path, report: PluginLoadReport) -> None:
+    """Import every subdirectory of plugins_dir that has an entry file."""
+    if not plugins_dir.exists():
+        return
+    for child in sorted(plugins_dir.iterdir()):
+        if not child.is_dir():
+            continue
+        if child.name.startswith("_") or child.name.startswith("."):
+            continue
+        # Prefer __init__.py, fall back to plugin.py.
+        entry = None
+        for candidate in ("__init__.py", "plugin.py"):
+            p = child / candidate
+            if p.exists():
+                entry = p
+                break
+        if entry is None:
+            report.results.append(
+                PluginLoadResult(
+                    name=child.name,
+                    source=f"folder:{child}",
+                    loaded=False,
+                    error="no __init__.py or plugin.py found",
+                    path=str(child),
+                )
+            )
+            continue
+        modname = f"_pymss_plugin_{child.name}"
+        try:
+            _import_plugin_module(modname, entry)
+            report.results.append(
+                PluginLoadResult(
+                    name=child.name,
+                    source=f"folder:{child}",
+                    loaded=True,
+                    path=str(entry),
+                )
+            )
+            logger.debug("loaded plugin '%s' from %s", child.name, entry)
+        except Exception as exc:  # noqa: BLE001
+            report.results.append(
+                PluginLoadResult(
+                    name=child.name,
+                    source=f"folder:{child}",
+                    loaded=False,
+                    error=f"{type(exc).__name__}: {exc}",
+                    path=str(entry),
+                )
+            )
+            logger.warning("plugin '%s' failed to load: %s", child.name, exc)
+
+
+def _scan_entrypoints(report: PluginLoadReport) -> None:
+    """Import every declared pymss.plugins entry point."""
+    try:
+        eps = entry_points()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("entry_points() failed: %s", exc)
+        return
+    # Compatible across Python 3.10+ (EntryPoints) and older (dict).
+    group_eps = []
+    try:
+        group_eps = list(eps.select(group=ENTRYPOINT_GROUP))  # py3.10+
+    except AttributeError:
+        group_eps = list(eps.get(ENTRYPOINT_GROUP, []))  # type: ignore[union-attr]
+    for ep in group_eps:
+        try:
+            ep.load()
+            report.results.append(
+                PluginLoadResult(name=ep.name, source="entrypoint", loaded=True)
+            )
+            logger.debug("loaded entrypoint plugin '%s'", ep.name)
+        except Exception as exc:  # noqa: BLE001
+            report.results.append(
+                PluginLoadResult(
+                    name=ep.name,
+                    source="entrypoint",
+                    loaded=False,
+                    error=f"{type(exc).__name__}: {exc}",
+                )
+            )
+            logger.warning("entrypoint plugin '%s' failed: load: %s", ep.name, exc)
+
+
+def bootstrap(force: bool = False) -> PluginLoadReport:
+    """Discover and load all plugins.
+
+    Idempotent: subsequent calls return the cached report unless ``force=True``.
+    """
+    global _LAST_REPORT
+    if _LAST_REPORT is not None and _LAST_REPORT.bootstrapped and not force:
+        return _LAST_REPORT
+
+    report = PluginLoadReport(bootstrapped=True)
+    plugins_dir = get_plugins_dir()
+    _scan_folder(plugins_dir, report)
+    _scan_entrypoints(report)
+    _LAST_REPORT = report
+    return report
+
+
+def reset() -> None:
+    """Clear the cached bootstrap report (mainly for tests)."""
+    global _LAST_REPORT
+    _LAST_REPORT = None
+
+
+__all__ = [
+    "DEFAULT_PLUGINS_DIR",
+    "ENTRYPOINT_GROUP",
+    "PluginLoadResult",
+    "PluginLoadReport",
+    "bootstrap",
+    "get_plugins_dir",
+    "get_last_report",
+    "reset",
+]

--- a/pymss/plugins/registry.py
+++ b/pymss/plugins/registry.py
@@ -1,0 +1,276 @@
+"""Plugin system: capability registry and node/CLI registration API.
+
+Design reference: docs/plugins.md (when ported to this branch).
+
+Two decoupled concepts:
+- Capability: a named function registered into a global pool. Does not know
+  who calls it.
+- Consumer: a workflow node or CLI command that looks up a capability by name.
+
+Providers and consumers can ship in different packages, coupled only by the
+capability name.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class CapabilityNotFound(KeyError):
+    """Raised when a required capability is not registered.
+
+    Consumers (nodes / CLI commands) catch this to give a more specific hint,
+    e.g. "SaveAudioOpus needs the opus_encode capability; run `pymss install
+    opus`".
+    """
+
+    def __init__(self, name: str):
+        self.name = name
+        super().__init__(
+            f"capability '{name}' is not registered. Install a plugin that "
+            f"provides it (e.g. `pymss install <name>`), or register it via "
+            f"pymss.plugins.register_capability."
+        )
+
+
+@dataclass
+class Capability:
+    """A registered capability: a name + a callable + optional metadata."""
+
+    name: str
+    func: Callable[..., Any]
+    source: str = "builtin"  # which plugin/package provided it
+    description: str = ""
+
+
+@dataclass
+class NodeRegistration:
+    """A registered workflow node executor."""
+
+    node_type: str
+    func: Callable[..., Any]
+    source: str = "builtin"
+    description: str = ""
+
+
+@dataclass
+class CLIRegistration:
+    """A registered CLI subcommand path, e.g. ("opus", "encode")."""
+
+    path: tuple[str, ...]
+    func: Callable[..., Any]
+    help: str = ""
+    source: str = "builtin"
+    add_arguments: Callable[[Any], None] | None = None  # optional argparse hook
+
+
+@dataclass
+class PluginRegistry:
+    """Global registry for capabilities, nodes, and CLI commands.
+
+    A single shared instance is exposed as `_REGISTRY`. pymss core registers
+    built-in capabilities at startup; plugins add more via the public API.
+    """
+
+    capabilities: dict[str, Capability] = field(default_factory=dict)
+    nodes: dict[str, NodeRegistration] = field(default_factory=dict)
+    cli_commands: list[CLIRegistration] = field(default_factory=list)
+
+    # Names that plugins must never override (pymss / comfy-mss built-ins).
+    # Only enforced for node registrations; capabilities use last-writer-wins
+    # with a warning.
+    _reserved_node_types: set[str] = field(default_factory=set)
+
+    # ---- capability API ----
+    def register_capability(
+        self,
+        name: str,
+        func: Callable[..., Any],
+        *,
+        source: str = "builtin",
+        description: str = "",
+    ) -> None:
+        if name in self.capabilities and self.capabilities[name].source != source:
+            logger.warning(
+                "capability '%s' already registered by '%s'; overriding with '%s'",
+                name,
+                self.capabilities[name].source,
+                source,
+            )
+        self.capabilities[name] = Capability(
+            name=name, func=func, source=source, description=description
+        )
+
+    def get_capability(self, name: str) -> Callable[..., Any]:
+        try:
+            return self.capabilities[name].func
+        except KeyError as exc:
+            raise CapabilityNotFound(name) from exc
+
+    def has_capability(self, name: str) -> bool:
+        return name in self.capabilities
+
+    # ---- node API ----
+    def reserve_node_type(self, node_type: str) -> None:
+        """Mark a node type as a pymss/comfy-mss built-in that plugins cannot override."""
+        self._reserved_node_types.add(node_type)
+
+    def register_node(
+        self,
+        node_type: str,
+        func: Callable[..., Any],
+        *,
+        source: str = "builtin",
+        description: str = "",
+        allow_override_builtin: bool = False,
+    ) -> None:
+        if node_type in self._reserved_node_types and not allow_override_builtin:
+            raise ValueError(
+                f"node type '{node_type}' is a reserved pymss built-in and "
+                f"cannot be registered by plugins."
+            )
+        if node_type in self.nodes:
+            logger.warning(
+                "node type '%s' already registered by '%s'; overriding with '%s'",
+                node_type,
+                self.nodes[node_type].source,
+                source,
+            )
+        self.nodes[node_type] = NodeRegistration(
+            node_type=node_type, func=func, source=source, description=description
+        )
+
+    def get_node(self, node_type: str) -> Callable[..., Any] | None:
+        reg = self.nodes.get(node_type)
+        return reg.func if reg else None
+
+    # ---- CLI API ----
+    def register_cli(
+        self,
+        path: str | tuple[str, ...],
+        func: Callable[..., Any],
+        *,
+        help: str = "",
+        source: str = "builtin",
+        add_arguments: Callable[[Any], None] | None = None,
+    ) -> None:
+        if isinstance(path, str):
+            path_tuple = tuple(path.split())
+        else:
+            path_tuple = tuple(path)
+        if not path_tuple:
+            raise ValueError("CLI command path must be non-empty")
+        self.cli_commands.append(
+            CLIRegistration(
+                path=path_tuple,
+                func=func,
+                help=help,
+                source=source,
+                add_arguments=add_arguments,
+            )
+        )
+
+
+# Single shared registry instance.
+_REGISTRY: PluginRegistry = PluginRegistry()
+
+
+# ---------------------------------------------------------------------------
+# Public registration API (used by plugins via `from pymss.plugins import ...`)
+# ---------------------------------------------------------------------------
+
+
+def register_capability(
+    name: str,
+    func: Callable[..., Any] | None = None,
+    *,
+    source: str = "plugin",
+    description: str = "",
+):
+    """Register a named capability, or use as a decorator.
+
+    Usage (direct):
+        register_capability("opus_encode", opus_encode_fn, source="my-plugin")
+
+    Usage (decorator):
+        @register_capability("eq")
+        def eq(audio, sample_rate, low_gain=0, mid_gain=0, high_gain=0):
+            ...
+    """
+    if func is None:
+        def decorator(f: Callable[..., Any]):
+            _REGISTRY.register_capability(name, f, source=source, description=description)
+            return f
+        return decorator
+    _REGISTRY.register_capability(name, func, source=source, description=description)
+    return func
+
+
+def register_node(
+    node_type: str,
+    func: Callable[..., Any] | None = None,
+    *,
+    source: str = "plugin",
+    description: str = "",
+):
+    """Register a workflow node executor. See register_capability for decorator use."""
+    if func is None:
+        def decorator(f: Callable[..., Any]):
+            _REGISTRY.register_node(node_type, f, source=source, description=description)
+            return f
+        return decorator
+    _REGISTRY.register_node(node_type, func, source=source, description=description)
+    return func
+
+
+def register_cli(
+    path: str | tuple[str, ...],
+    func: Callable[..., Any] | None = None,
+    *,
+    help: str = "",
+    source: str = "plugin",
+    add_arguments: Callable[[Any], None] | None = None,
+):
+    """Register a CLI subcommand under `pymss <path[0]> <path[1]> ...`.
+
+    path: e.g. "opus encode" or ("opus", "encode"). The first element is the
+    plugin's namespace; it must not collide with official pymss commands.
+    """
+    if func is None:
+        def decorator(f: Callable[..., Any]):
+            _REGISTRY.register_cli(
+                path, f, help=help, source=source, add_arguments=add_arguments
+            )
+            return f
+        return decorator
+    _REGISTRY.register_cli(path, func, help=help, source=source, add_arguments=add_arguments)
+    return func
+
+
+def require_capability(name: str) -> Callable[..., Any]:
+    """Look up a capability by name; raise CapabilityNotFound if missing.
+
+    Intended for use inside node executors and CLI command handlers."""
+    return _REGISTRY.get_capability(name)
+
+
+def get_registry() -> PluginRegistry:
+    """Return the shared plugin registry (for introspection / pymss internals)."""
+    return _REGISTRY
+
+
+__all__ = [
+    "CapabilityNotFound",
+    "PluginRegistry",
+    "register_capability",
+    "register_node",
+    "register_cli",
+    "require_capability",
+    "get_registry",
+    "_REGISTRY",
+]

--- a/pymss/separator.py
+++ b/pymss/separator.py
@@ -398,17 +398,19 @@ def _prepare_mix_channels(mix, is_stereo, logger):
 
     Returns:
         Any: Computed result."""
+    from .plugins.builtins import to_mono
+
     if is_stereo and len(mix.shape) == 1:
         logger.warning("Track is mono, but model is stereo, adding a second channel.")
         return np.stack([mix, mix], axis=0)
     if is_stereo and len(mix.shape) > 2:
         logger.warning("Track has more than 2 channels, taking mean of all channels and adding a second channel.")
-        mono = np.mean(mix, axis=0)
+        mono = to_mono(mix)
         return np.stack([mono, mono], axis=0)
     if not is_stereo:
         if len(mix.shape) != 1:
             logger.warning("Track has more than 1 channels, but model is mono, taking mean of all channels.")
-            return np.mean(mix, axis=0, keepdims=True)
+            return to_mono(mix)[None, :]
         return mix[None, :]
     return mix
 
@@ -426,11 +428,12 @@ def _standardize_mix(mix, enabled, logger):
     if not enabled:
         return mix, None
 
-    mono = mix.mean(0)
-    mean = mono.mean()
-    std = mono.std()
+    from .plugins.builtins import standardize
+
+    standardized, stats = standardize(mix)
+    mean, std = stats
     logger.debug(f"Standardize mix with mean: {mean}, std: {std}")
-    return (mix - mean) / std, (mean, std)
+    return standardized, stats
 
 
 def _normalize_outputs(results, enabled, logger, target_peak=OUTPUT_NORMALIZE_PEAK):
@@ -447,6 +450,8 @@ def _normalize_outputs(results, enabled, logger, target_peak=OUTPUT_NORMALIZE_PE
     if not enabled:
         return results
 
+    from .plugins.builtins import normalize_peak
+
     peak = max(
         (float(np.max(np.abs(np.asarray(audio)))) for audio in results.values() if np.asarray(audio).size),
         default=0.0,
@@ -455,9 +460,8 @@ def _normalize_outputs(results, enabled, logger, target_peak=OUTPUT_NORMALIZE_PE
         logger.debug("Skipping output normalize because peak is zero or not finite.")
         return results
 
-    gain = target_peak / peak
-    logger.debug(f"Normalize output stems with peak: {peak}, target_peak: {target_peak}, gain: {gain}")
-    return {stem: np.asarray(audio) * gain for stem, audio in results.items()}
+    logger.debug(f"Normalize output stems with peak: {peak}, target_peak: {target_peak}")
+    return {stem: normalize_peak(audio, target_peak=target_peak) for stem, audio in results.items()}
 
 
 def _destandardize(estimates, stats):
@@ -469,7 +473,11 @@ def _destandardize(estimates, stats):
 
     Returns:
         Any: Computed result."""
-    return estimates if stats is None else estimates * stats[1] + stats[0]
+    if stats is None:
+        return estimates
+    from .plugins.builtins import destandardize
+
+    return destandardize(estimates, stats)
 
 
 def _tta_variants(mix, use_tta, logger):

--- a/test/test_audio_formats.py
+++ b/test/test_audio_formats.py
@@ -1,0 +1,78 @@
+"""Round-trip encode/decode tests for save_audio across all supported formats."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+from pymss.audio_io import load_audio, save_audio
+
+
+@pytest.fixture
+def tone():
+    """2s stereo 440Hz tone at 44100 Hz, peak ~0.3."""
+    sr = 44100
+    t = np.linspace(0, 2, sr * 2, False)
+    mono = (0.3 * np.sin(2 * np.pi * 440 * t)).astype(np.float32)
+    return np.stack([mono, mono], axis=1), sr
+
+
+@pytest.mark.parametrize(
+    "fmt,ext,params",
+    [
+        ("wav", ".wav", {"wav_bit_depth": "FLOAT"}),
+        ("wav", ".wav", {"wav_bit_depth": "PCM_16"}),
+        ("flac", ".flac", {}),
+        ("mp3", ".mp3", {"mp3_bit_rate": "320k"}),
+        ("m4a", ".m4a", {}),
+        ("aac", ".aac", {"aac_bit_rate": "128k"}),
+        ("vorbis", ".ogg", {}),
+        ("ogg", ".ogg", {}),  # alias of vorbis
+        ("opus", ".opus", {}),
+    ],
+)
+def test_save_audio_roundtrip(tone, fmt, ext, params):
+    audio, sr = tone
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, f"out{ext}")
+        save_audio(path, audio, sr, fmt, params)
+        assert os.path.getsize(path) > 0
+        loaded, loaded_sr = load_audio(path)
+        # Sample rate: opus is resampled to 48000, others keep 44100.
+        if fmt == "opus":
+            assert loaded_sr == 48000
+        else:
+            assert loaded_sr == sr
+        # Channel count preserved. load_audio returns channel-first: (channels, samples).
+        assert loaded.shape[0] == 2
+        # Lossless formats preserve peak exactly; lossy ones roughly.
+        peak = float(np.abs(loaded).max())
+        if fmt in {"wav", "flac"}:
+            assert 0.25 < peak < 0.35
+        else:
+            assert 0.2 < peak < 0.4
+
+
+def test_opus_resamples_non_native_sr(tone):
+    """opus only supports 8/12/16/24/48 kHz; 44100 must be resampled (to 48000)."""
+    audio, sr = tone
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "out.opus")
+        save_audio(path, audio, sr, "opus", {})
+        _, loaded_sr = load_audio(path)
+        assert loaded_sr == 48000
+
+
+def test_mono_save(tone):
+    """Mono audio saves and loads back with one channel."""
+    audio, sr = tone
+    mono = audio[:, 0]
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "mono.wav")
+        save_audio(path, mono, sr, "wav", {"wav_bit_depth": "PCM_16"})
+        loaded, _ = load_audio(path)
+        # mono loads back as 1-D (samples,)
+        assert loaded.ndim == 1

--- a/test/test_builtin_capabilities.py
+++ b/test/test_builtin_capabilities.py
@@ -166,3 +166,64 @@ def test_ensemble_registered_as_capability():
     reg = get_registry()
     assert "ensemble" in reg.capabilities
     assert reg.capabilities["ensemble"].source == "builtin"
+
+
+# ---------------------------------------------------------------------------
+# empty_audio / eq / resample (new builtins)
+# ---------------------------------------------------------------------------
+
+
+def test_empty_audio_stereo():
+    out = require_capability("empty_audio")(duration=1.0, sample_rate=44100, channels=2)
+    assert out.shape == (2, 44100)
+    assert np.all(out == 0)
+
+
+def test_empty_audio_mono():
+    out = require_capability("empty_audio")(duration=0.5, sample_rate=8000, channels=1)
+    assert out.shape == (4000,)
+
+
+def test_resample_changes_length():
+    a = np.random.randn(2, 44100).astype(np.float32)
+    out = require_capability("resample")(a, 44100, 16000)
+    assert out.shape[0] == 2
+    assert abs(out.shape[1] - 16000) < 100  # ~1s at 16kHz
+
+
+def test_resample_same_sr_passthrough():
+    a = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+    out = require_capability("resample")(a, 44100, 44100)
+    assert np.allclose(out, a)
+
+
+def test_eq_low_boost_increases_low_energy():
+    """Boosting low band should increase low-frequency content."""
+    sr = 44100
+    t = np.linspace(0, 1, sr, False)
+    sig = (0.3 * np.sin(2 * np.pi * 100 * t) + 0.3 * np.sin(2 * np.pi * 5000 * t)).astype(np.float32)
+
+    out = require_capability("eq")(sig, sr, low_gain_db=12.0, low_freq=100)
+
+    # Low-band energy ratio should go up after low-shelf boost.
+    def lowband_ratio(x):
+        spec = np.abs(np.fft.rfft(x))
+        return float(spec[: len(spec) // 8].sum() / spec.sum())
+
+    assert lowband_ratio(out) > lowband_ratio(sig)
+
+
+def test_eq_zero_gain_passthrough():
+    """With all gains at 0 dB, output should equal input."""
+    sr = 44100
+    t = np.linspace(0, 1, sr, False)
+    sig = (0.3 * np.sin(2 * np.pi * 440 * t)).astype(np.float32)
+    out = require_capability("eq")(sig, sr)  # all gains default 0
+    assert np.allclose(out, sig, atol=1e-6)
+
+
+def test_eq_preserves_shape():
+    sr = 44100
+    stereo = np.random.randn(2, sr).astype(np.float32)
+    out = require_capability("eq")(stereo, sr, mid_gain_db=3.0, mid_freq=1000, mid_q=1.0)
+    assert out.shape == stereo.shape

--- a/test/test_builtin_capabilities.py
+++ b/test/test_builtin_capabilities.py
@@ -1,0 +1,168 @@
+"""Tests for built-in capabilities: DSP and channel operations registered
+into the plugin system, and verification that separator/ensemble consume them."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pymss.plugins import get_registry, require_capability
+
+
+@pytest.fixture(autouse=True)
+def _ensure_builtins():
+    """Built-ins register on `import pymss`; nothing to do per-test."""
+    yield
+
+
+def _mono(samples=10):
+    return np.linspace(0.1, 1.0, samples, dtype=np.float32)
+
+
+def _stereo(samples=10):
+    return np.stack([_mono(samples), _mono(samples) * 2], axis=0)
+
+
+# ---------------------------------------------------------------------------
+# Capability presence
+# ---------------------------------------------------------------------------
+
+
+def test_all_builtins_registered():
+    reg = get_registry()
+    expected = {
+        "to_mono", "split_channels", "join_channels",
+        "adjust_volume", "invert_phase", "normalize_peak",
+        "standardize", "destandardize", "trim", "concat", "mix",
+        "ensemble",
+    }
+    assert expected.issubset(reg.capabilities.keys())
+    for name in expected:
+        assert reg.capabilities[name].source == "builtin"
+
+
+# ---------------------------------------------------------------------------
+# Channel ops
+# ---------------------------------------------------------------------------
+
+
+def test_to_mono_from_stereo():
+    stereo = _stereo()
+    out = require_capability("to_mono")(stereo)
+    assert out.ndim == 1
+    # mean of row0 (x) and row1 (2x) = 1.5x
+    assert np.allclose(out, _mono() * 1.5)
+
+
+def test_to_mono_passthrough_mono():
+    a = _mono()
+    assert require_capability("to_mono")(a) is a or np.allclose(require_capability("to_mono")(a), a)
+
+
+def test_split_join_roundtrip():
+    stereo = _stereo()
+    parts = require_capability("split_channels")(stereo)
+    assert len(parts) == 2
+    rebuilt = require_capability("join_channels")(parts)
+    assert np.allclose(rebuilt, stereo)
+
+
+def test_join_channels_length_mismatch_raises():
+    a = _mono(10)
+    b = _mono(11)
+    with pytest.raises(ValueError, match="same length"):
+        require_capability("join_channels")([a, b])
+
+
+# ---------------------------------------------------------------------------
+# DSP ops
+# ---------------------------------------------------------------------------
+
+
+def test_invert_phase():
+    a = _mono()
+    assert np.allclose(require_capability("invert_phase")(a), -a)
+
+
+def test_adjust_volume():
+    a = _mono()
+    # +6 dB ≈ 2x amplitude
+    out = require_capability("adjust_volume")(a, gain_db=6.0206)
+    assert np.allclose(out, a * 2.0, atol=1e-4)
+
+
+def test_normalize_peak():
+    a = np.array([0.5, -0.25, 0.1], dtype=np.float32)
+    out = require_capability("normalize_peak")(a, target_peak=0.99)
+    assert np.isclose(np.abs(out).max(), 0.99, atol=1e-5)
+
+
+def test_normalize_peak_silence_noop():
+    a = np.zeros(10, dtype=np.float32)
+    out = require_capability("normalize_peak")(a)
+    assert np.allclose(out, 0.0)
+
+
+def test_standardize_destandardize_roundtrip():
+    a = _stereo()
+    std_a, stats = require_capability("standardize")(a)
+    restored = require_capability("destandardize")(std_a, stats)
+    assert np.allclose(restored, a, atol=1e-5)
+
+
+def test_trim():
+    a = _mono(1000)
+    sr = 1000
+    out = require_capability("trim")(a, sr, start=0.1, duration=0.2)
+    assert out.shape[-1] == 200  # 0.2s at 1000Hz
+
+
+def test_concat():
+    a = _mono(5)
+    b = _mono(5)
+    out = require_capability("concat")([a, b])
+    assert out.shape[-1] == 10
+
+
+def test_mix_add_mean_subtract():
+    a = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+    b = np.array([0.5, 0.5, 0.5], dtype=np.float32)
+    assert np.allclose(require_capability("mix")([a, b], mode="add"), [1.5, 2.5, 3.5])
+    assert np.allclose(require_capability("mix")([a, b], mode="mean"), [0.75, 1.25, 1.75])
+    assert np.allclose(require_capability("mix")([a, b], mode="subtract"), [0.5, 1.5, 2.5])
+
+
+# ---------------------------------------------------------------------------
+# separator consumes built-in capabilities
+# ---------------------------------------------------------------------------
+
+
+def test_separator_uses_builtin_standardize():
+    """The separator's private _standardize_mix must delegate to the builtin."""
+    import inspect
+    from pymss.separator import _standardize_mix
+
+    src = inspect.getsource(_standardize_mix)
+    assert "from .plugins.builtins import standardize" in src
+
+
+def test_separator_uses_builtin_normalize():
+    import inspect
+    from pymss.separator import _normalize_outputs
+
+    src = inspect.getsource(_normalize_outputs)
+    assert "from .plugins.builtins import normalize_peak" in src
+
+
+def test_separator_uses_builtin_channels():
+    import inspect
+    from pymss.separator import _prepare_mix_channels
+
+    src = inspect.getsource(_prepare_mix_channels)
+    assert "from .plugins.builtins import to_mono" in src
+
+
+def test_ensemble_registered_as_capability():
+    reg = get_registry()
+    assert "ensemble" in reg.capabilities
+    assert reg.capabilities["ensemble"].source == "builtin"

--- a/test/test_codec_capabilities.py
+++ b/test/test_codec_capabilities.py
@@ -1,0 +1,99 @@
+"""Tests for codec capabilities: save_audio dispatches via the capability pool,
+and each format encoder is independently callable."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+from pymss import load_audio, save_audio
+from pymss.plugins import CapabilityNotFound, get_registry, require_capability
+from pymss.plugins.codecs import supported_formats
+
+
+@pytest.fixture
+def tone():
+    sr = 44100
+    t = np.linspace(0, 1, sr, False)
+    mono = (0.3 * np.sin(2 * np.pi * 440 * t)).astype(np.float32)
+    return np.stack([mono, mono], axis=1), sr
+
+
+def test_all_builtin_codecs_registered():
+    reg = get_registry()
+    for fmt in ("wav", "flac", "mp3", "m4a", "aac", "opus", "vorbis", "ogg"):
+        cap = f"{fmt}_encode"
+        assert cap in reg.capabilities, f"missing {cap}"
+        assert reg.capabilities[cap].source == "builtin"
+
+
+def test_supported_formats_lists_all():
+    fmts = supported_formats()
+    for fmt in ("wav", "flac", "mp3", "m4a", "aac", "opus", "vorbis", "ogg"):
+        assert fmt in fmts
+
+
+def test_save_audio_unknown_format_raises(tone):
+    """Unknown formats must raise CapabilityNotFound, not silently fall back to wav."""
+    audio, sr = tone
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "x.wma")
+        with pytest.raises(CapabilityNotFound):
+            save_audio(path, audio, sr, "wma", {})
+
+
+def test_encode_capability_callable_directly(tone):
+    """require_capability('mp3_encode') works without going through save_audio."""
+    audio, sr = tone
+    encode = require_capability("mp3_encode")
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "direct.mp3")
+        encode(audio, sr, path, bit_rate="128k")
+        assert os.path.getsize(path) > 0
+        loaded, loaded_sr = load_audio(path)
+        assert loaded_sr == sr
+
+
+def test_save_audio_dispatches_to_capability(tone):
+    """save_audio and the direct capability produce the same format output."""
+    audio, sr = tone
+    with tempfile.TemporaryDirectory() as d:
+        p1 = os.path.join(d, "via_save.flac")
+        save_audio(p1, audio, sr, "flac", {})
+        p2 = os.path.join(d, "via_cap.flac")
+        require_capability("flac_encode")(audio, sr, p2)
+        # Both are valid FLAC; sizes should be in the same ballpark.
+        assert abs(os.path.getsize(p1) - os.path.getsize(p2)) < 1000
+
+
+def test_legacy_audio_params_still_work(tone):
+    """Legacy audio_params keys (wav_bit_depth, mp3_bit_rate) map through."""
+    audio, sr = tone
+    with tempfile.TemporaryDirectory() as d:
+        # wav with PCM_16
+        p16 = os.path.join(d, "16.wav")
+        save_audio(p16, audio, sr, "wav", {"wav_bit_depth": "PCM_16"})
+        # wav with FLOAT
+        pf = os.path.join(d, "f.wav")
+        save_audio(pf, audio, sr, "wav", {"wav_bit_depth": "FLOAT"})
+        # PCM_16 file is smaller than FLOAT (16-bit vs 32-bit)
+        assert os.path.getsize(p16) < os.path.getsize(pf)
+
+        # mp3 with different bitrates
+        p128 = os.path.join(d, "128.mp3")
+        save_audio(p128, audio, sr, "mp3", {"mp3_bit_rate": "128k"})
+        p320 = os.path.join(d, "320.mp3")
+        save_audio(p320, audio, sr, "mp3", {"mp3_bit_rate": "320k"})
+        assert os.path.getsize(p128) < os.path.getsize(p320)
+
+
+def test_opus_capability_resamples(tone):
+    audio, sr = tone
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "out.opus")
+        require_capability("opus_encode")(audio, sr, path)
+        _, loaded_sr = load_audio(path)
+        assert loaded_sr == 48000  # opus resamples 44100 -> 48000

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -1,0 +1,283 @@
+"""Tests for the plugin system: registration API, folder-scan loading, install/uninstall."""
+
+from __future__ import annotations
+
+import os
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from pymss.plugins import (
+    CapabilityNotFound,
+    bootstrap,
+    get_plugins_dir,
+    get_registry,
+    register_capability,
+    register_cli,
+    register_node,
+    require_capability,
+    reset,
+)
+from pymss.plugins.install import InstallError, install, uninstall
+
+
+# ---------------------------------------------------------------------------
+# Registration API
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    """Each test starts with a clean registry and loader cache."""
+    reg = get_registry()
+    reg.capabilities.clear()
+    reg.nodes.clear()
+    reg.cli_commands.clear()
+    reg._reserved_node_types.clear()
+    reset()
+    yield
+    reg.capabilities.clear()
+    reg.nodes.clear()
+    reg.cli_commands.clear()
+    reg._reserved_node_types.clear()
+    reset()
+
+
+def test_register_capability_direct():
+    def fn(x):
+        return x + 1
+
+    register_capability("inc", fn, source="test")
+    assert require_capability("inc")(1) == 2
+
+
+def test_register_capability_decorator():
+    @register_capability("double")
+    def double(x):
+        return x * 2
+
+    assert double(3) == 6  # decorator returns the original func
+    assert require_capability("double")(3) == 6
+
+
+def test_require_capability_missing_raises():
+    with pytest.raises(CapabilityNotFound) as exc_info:
+        require_capability("nope")
+    assert "nope" in str(exc_info.value)
+
+
+def test_register_node():
+    @register_node("MyPluginNode")
+    def handler(ctx, inputs):
+        return {"out": "ok"}
+
+    reg = get_registry()
+    assert reg.get_node("MyPluginNode") is handler
+
+
+def test_reserved_node_cannot_be_overridden_by_plugin():
+    reg = get_registry()
+    reg.reserve_node_type("mss_separate")
+
+    with pytest.raises(ValueError, match="reserved"):
+        register_node("mss_separate", lambda ctx, inputs: None, source="evil")
+
+
+def test_reserved_node_allows_builtin_override():
+    reg = get_registry()
+    reg.reserve_node_type("mss_separate")
+    # pymss core itself can register reserved nodes with the internal flag.
+    reg.register_node(
+        "mss_separate", lambda ctx, inputs: None, source="builtin", allow_override_builtin=True
+    )
+    assert reg.get_node("mss_separate") is not None
+
+
+def test_register_cli_parses_path():
+    register_cli("opus encode", lambda args: 0, help="encode opus")
+    reg = get_registry()
+    assert len(reg.cli_commands) == 1
+    assert reg.cli_commands[0].path == ("opus", "encode")
+
+
+# ---------------------------------------------------------------------------
+# Folder-scan loading
+# ---------------------------------------------------------------------------
+
+
+def _make_plugin_dir(plugins_dir: Path, name: str, body: str) -> Path:
+    d = plugins_dir / name
+    d.mkdir(parents=True)
+    (d / "__init__.py").write_text(textwrap.dedent(body))
+    return d
+
+
+def test_folder_scan_loads_plugin(tmp_path, monkeypatch):
+    plugins_dir = tmp_path / "plugins"
+    _make_plugin_dir(
+        plugins_dir,
+        "myplug",
+        """
+        from pymss.plugins import register_capability
+        register_capability("myplug_thing", lambda x: x * 10, source="myplug")
+        """,
+    )
+    monkeypatch.setenv("PYMSS_PLUGINS_DIR", str(plugins_dir))
+    reset()
+
+    report = bootstrap()
+    assert report.bootstrapped
+    assert "myplug" in report.loaded_names
+    assert require_capability("myplug_thing")(5) == 50
+
+
+def test_folder_scan_isolates_failures(tmp_path, monkeypatch):
+    plugins_dir = tmp_path / "plugins"
+    # good plugin
+    _make_plugin_dir(
+        plugins_dir,
+        "good",
+        """
+        from pymss.plugins import register_capability
+        register_capability("good_cap", lambda: 1, source="good")
+        """,
+    )
+    # bad plugin (ImportError)
+    bad = plugins_dir / "bad"
+    bad.mkdir()
+    (bad / "__init__.py").write_text("raise RuntimeError('boom')\n")
+    monkeypatch.setenv("PYMSS_PLUGINS_DIR", str(plugins_dir))
+    reset()
+
+    report = bootstrap()
+    assert "good" in report.loaded_names
+    failed = {r.name: r for r in report.failed}
+    assert "bad" in failed
+    assert "boom" in failed["bad"].error
+    # good plugin's capability still registered despite bad plugin failing
+    assert require_capability("good_cap")() == 1
+
+
+def test_bootstrap_is_idempotent(monkeypatch, tmp_path):
+    monkeypatch.setenv("PYMSS_PLUGINS_DIR", str(tmp_path / "empty"))
+    reset()
+    r1 = bootstrap()
+    r2 = bootstrap()
+    assert r1 is r2
+    r3 = bootstrap(force=True)
+    assert r3 is not r1
+
+
+def test_get_plugins_dir_env_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("PYMSS_PLUGINS_DIR", str(tmp_path / "custom"))
+    assert get_plugins_dir() == tmp_path / "custom"
+
+
+def test_get_plugins_dir_default(monkeypatch):
+    monkeypatch.delenv("PYMSS_PLUGINS_DIR", raising=False)
+    from pymss.plugins.loader import DEFAULT_PLUGINS_DIR
+
+    assert get_plugins_dir() == DEFAULT_PLUGINS_DIR
+
+
+# ---------------------------------------------------------------------------
+# Install / uninstall
+# ---------------------------------------------------------------------------
+
+
+def test_install_from_local_path(tmp_path, monkeypatch):
+    plugins_dir = tmp_path / "installed"
+    # source plugin
+    src = tmp_path / "src" / "myplugin"
+    src.mkdir(parents=True)
+    (src / "__init__.py").write_text(
+        "from pymss.plugins import register_capability\n"
+        "register_capability('copied_cap', lambda: 42, source='myplugin')\n"
+    )
+    monkeypatch.setenv("PYMSS_PLUGINS_DIR", str(plugins_dir))
+
+    result = install(str(src))
+    assert result.source == "path"
+    assert result.name == "myplugin"
+    assert (plugins_dir / "myplugin" / "__init__.py").exists()
+
+    # The copied plugin loads correctly.
+    reset()
+    bootstrap()
+    assert require_capability("copied_cap")() == 42
+
+
+def test_install_duplicate_raises(tmp_path, monkeypatch):
+    plugins_dir = tmp_path / "installed"
+    src = tmp_path / "src" / "dup"
+    src.mkdir(parents=True)
+    (src / "__init__.py").write_text("")
+    monkeypatch.setenv("PYMSS_PLUGINS_DIR", str(plugins_dir))
+
+    install(str(src))
+    with pytest.raises(InstallError, match="already exists"):
+        install(str(src))
+
+
+def test_uninstall_removes_dir(tmp_path, monkeypatch):
+    plugins_dir = tmp_path / "installed"
+    src = tmp_path / "src" / "gone"
+    src.mkdir(parents=True)
+    (src / "__init__.py").write_text("")
+    monkeypatch.setenv("PYMSS_PLUGINS_DIR", str(plugins_dir))
+
+    install(str(src))
+    dest = plugins_dir / "gone"
+    assert dest.exists()
+    removed = uninstall("gone")
+    assert removed == dest
+    assert not dest.exists()
+
+
+def test_uninstall_missing_raises(tmp_path, monkeypatch):
+    monkeypatch.setenv("PYMSS_PLUGINS_DIR", str(tmp_path / "empty"))
+    with pytest.raises(InstallError, match="no installed plugin"):
+        uninstall("ghost")
+
+
+def test_install_unknown_name_without_registry_raises(tmp_path, monkeypatch):
+    # Point registry at a non-existent URL so the fetch fails fast.
+    monkeypatch.setenv("PYMSS_PLUGINS_DIR", str(tmp_path / "p"))
+    monkeypatch.setenv("PYMSS_PLUGINS_REGISTRY", "http://127.0.0.1:1/nope.json")
+    with pytest.raises(InstallError, match="registry|URL|path|fetch"):
+        install("nonexistent-plugin-name")
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke (argparse wiring)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_install_and_plugins_list(tmp_path, monkeypatch):
+    from pymss.cli import main
+
+    plugins_dir = tmp_path / "cli_plugins"
+    monkeypatch.setenv("PYMSS_PLUGINS_DIR", str(plugins_dir))
+    reset()
+
+    src = tmp_path / "src" / "clipplug"
+    src.mkdir(parents=True)
+    (src / "__init__.py").write_text(
+        "from pymss.plugins import register_capability\n"
+        "register_capability('cli_cap', lambda: 7, source='clipplug')\n"
+    )
+
+    # install
+    rc = main(["install", str(src)])
+    assert rc == 0
+
+    # plugins list (bootstrap loads the freshly installed plugin)
+    reset()
+    rc = main(["plugins", "list"])
+    assert rc == 0
+
+    # plugins dir
+    rc = main(["plugins", "dir"])
+    assert rc == 0


### PR DESCRIPTION
## Summary

Introduces a plugin system for pymss and migrates core DSP / channel / codec functionality onto it. pymss itself registers built-in capabilities through the same API plugins use — core and extensions share one mechanism, not two.

## Core model: capabilities + consumers (decoupled)

- **Capability**: a named function in a global pool. Does not know who calls it.
- **Consumer**: a node / CLI / library call that looks up a capability by name.
- Provider and consumer can ship in different packages, coupled only by the capability name.

This lets someone adapt a node (e.g. `SaveAudioOpus`) by reusing an already-registered capability (e.g. `opus_encode`) without rewriting the encoder.

## What's in this PR

### 1. Plugin framework (`pymss/plugins/`)
- `registry.py`: flat capability pool + `register_capability` / `register_node` / `register_cli` / `require_capability`. `CapabilityNotFound` is raised with install guidance when a needed capability is missing (no silent degradation).
- `loader.py`: folder-scan discovery (`~/.pymss/plugins/`, overridable via `PYMSS_PLUGINS_DIR`) + optional `entry_points`. A single plugin failing to load never blocks others; failures are recorded and surfaced via `pymss plugins list`.
- `install.py`: `pymss install <name|url|path>` — official registry name, git URL, or local dir. Official registry is fetched from a separate `pymss-plugins` repo (configurable), so adding official plugins needs no pymss release. Plugin dependencies are left to plugin authors.
- CLI: `pymss install` / `pymss uninstall` / `pymss plugins list` / `pymss plugins dir`.
- Node-name protection: built-in node types are reserved; plugins cannot override them.

### 2. Built-in capabilities (pymss eats its own dogfood)
- **DSP / channel** (`builtins.py`, 15 capabilities): `to_mono`, `split_channels`, `join_channels`, `adjust_volume`, `invert_phase`, `normalize_peak`, `standardize`/`destandardize`, `trim`, `concat`, `mix` (add/mean/subtract/min/max), `empty_audio`, `eq` (3-band biquad via scipy), `resample` (librosa), `ensemble` (8 algorithms).
- **Codec** (`codecs.py`, 8 capabilities): `wav/flac/mp3/m4a/aac/opus/vorbis/ogg` each as a `{fmt}_encode` capability. `save_audio` is now a thin dispatcher that looks up `f"{format}_encode"` in the pool.

### 3. `save_audio` now supports opus / aac / vorbis / ogg natively
These formats are encoded by `soundfile` (libsndfile) and `PyAV` (ffmpeg), which pymss already depends on — **no new dependencies**. Opus auto-resamples non-native sample rates (8/12/16/24/48 kHz) via librosa.

This corrects the earlier prototype behavior of silently mapping `SaveAudioOpus -> m4a`. Unknown formats now raise `CapabilityNotFound` instead of falling through to wav.

### 4. separator/ensemble consume built-in capabilities
`_prepare_mix_channels` → `to_mono`; `_standardize_mix` → `standardize`; `_normalize_outputs` → `normalize_peak`; `_destandardize` → `destandardize`. External signatures and logger behavior unchanged.

## Key corrections from earlier prototypes
- **EQ does not need torchaudio.** ComfyUI uses it only because torch is its base. EQ is biquad filters; `scipy.signal` (already a pymss dep via librosa) implements it with standard Audio EQ Cookbook formulas. EQ is therefore built-in, not a plugin.
- **opus/aac/vorbis/ogg need no new deps.** soundfile + PyAV already encode them. opus no longer silently becomes m4a.

## Tests
- `test_plugins.py` (18): registration API, folder-scan isolation, idempotent bootstrap, env overrides, install/uninstall, CLI smoke.
- `test_audio_formats.py` (11): round-trip encode/read for all 8 formats.
- `test_builtin_capabilities.py` (24): every DSP/channel capability + source introspection proving separator delegates to builtins.
- `test_codec_capabilities.py` (7): codecs registered, unknown-format error, direct capability call, save_audio<->capability equivalence, legacy params mapping.

**84 passed / 8 skipped** (skips are real-model integration tests), no regression.

## Out of scope (follow-up PRs)
- Workflow / comfy-mss node adaptation layer (consuming these capabilities). The `feat/graph-workflow` branch prototyped nodes by piling DSP code into them; that approach is superseded by this capability model and will be redone as thin consumers.
- Official plugin repo (`pymss-plugins`) and example plugins (e.g. `pymss-dsp-pedalboard` for mastering effects, `pymss-dsp-loudnorm` for LUFS).
- Plugin design doc (`docs/plugins.md`).

## Decision log (confirmed in discussion)
| Decision | Conclusion |
|---|---|
| Capability classification | none — flat name table |
| Capability signatures | not unified |
| Provider/consumer coupling | by capability name only |
| Discovery | folder scan (default) + entry_points (optional) |
| Plugin dir | `~/.pymss/plugins/`, env-overridable |
| Install | `pymss install <name\|url\|path>` |
| Official registry | separate `pymss-plugins` repo |
| Plugin dependencies | author's responsibility |
| Built-in codecs | wav/flac/mp3/m4a/aac/opus/vorbis/ogg |
| Plugin CLI namespace | forced `pymss <plugin> ...` |
| Node name prefix | not forced; only overriding built-ins is forbidden |
