### PR TITLE
修复 inference_params["use_amp"] 未生效

### DIFF
--- a/pymss/separator.py
+++ b/pymss/separator.py
@@ -13,7 +13,7 @@ from time import time
 from tqdm import tqdm
 
 from .audio_io import load_audio, save_audio
-from .utils import clear_mlx_cache, demix, get_model_from_config
+from .utils import _resolve_use_amp, clear_mlx_cache, demix, get_model_from_config
 from .logger import get_separation_logger, set_log_level
 from .config import AttrDict
 
@@ -1148,7 +1148,7 @@ class MSSeparator:
                 f"MSS model params: chunk_size: {config.audio.get('chunk_size', config.inference.get('chunk_size', None))}, overlap_size: {config.inference.get('overlap_size', None)}, stem_batch_size: {config.inference.get('stem_batch_size', None)}"
             )
             self.logger.debug(
-                f"MSS model params: mask_mode: {config.inference.get('mask_mode', None)}, cuda_attention_backend: {config.inference.get('cuda_attention_backend', None)}, mps_attention_backend: {config.inference.get('mps_attention_backend', None)}, mps_mlx_min_tokens: {config.inference.get('mps_mlx_min_tokens', None)}, mps_model_backend: {config.inference.get('mps_model_backend', None)}, mps_model_compute_dtype: {config.inference.get('mps_model_compute_dtype', None)}"
+                f"MSS model params: use_amp: {_resolve_use_amp(config)}, mask_mode: {config.inference.get('mask_mode', None)}, cuda_attention_backend: {config.inference.get('cuda_attention_backend', None)}, mps_attention_backend: {config.inference.get('mps_attention_backend', None)}, mps_mlx_min_tokens: {config.inference.get('mps_mlx_min_tokens', None)}, mps_model_backend: {config.inference.get('mps_model_backend', None)}, mps_model_compute_dtype: {config.inference.get('mps_model_compute_dtype', None)}"
             )
 
     def apply_model_inference_config(self, model, config):

--- a/pymss/utils.py
+++ b/pymss/utils.py
@@ -310,6 +310,14 @@ def _autocast(device, enabled):
     return nullcontext()
 
 
+def _resolve_use_amp(config):
+    """Resolve the effective AMP setting for PyTorch inference."""
+    use_amp = config.inference.get("use_amp")
+    if use_amp is not None:
+        return bool(use_amp)
+    return bool(config.training.get("use_amp", True))
+
+
 def _source_names(config):
     """Implement the source names helper.
 
@@ -997,7 +1005,7 @@ def demix_track(config, model, mix, device, pbar=False, source_indices=None, pro
     use_complete_fast_path = device_type in ("cuda", "cpu")
     mix_device = _model_mix(mix, device)
 
-    with _autocast(device, config.training.get("use_amp", True)):
+    with _autocast(device, _resolve_use_amp(config)):
         with torch.inference_mode():
             result, counter = _init_overlap_buffers(config, mix, device, use_complete_fast_path, source_indices)
             progress = _ProgressContext(pbar, mix.shape[1], progress_callback, sample_rate=sample_rate)
@@ -1074,7 +1082,7 @@ def demix_track_demucs(config, model, mix, device, pbar=False, source_indices=No
     batch_size = config.inference.batch_size
     step = _get_inference_step(config, C)
 
-    with _autocast(device, config.training.get("use_amp", True)):
+    with _autocast(device, _resolve_use_amp(config)):
         with torch.inference_mode():
             req_shape = (_source_count(config, source_indices),) + tuple(mix.shape)
             result = torch.zeros(req_shape, dtype=torch.float32)
@@ -1147,7 +1155,7 @@ def demix(
             message="Processing audio",
         )
         progress.emit(0)
-        with _autocast(device, config.training.get("use_amp", True)):
+        with _autocast(device, _resolve_use_amp(config)):
             with torch.inference_mode():
                 estimates = (
                     apply_legacy_model(

--- a/test/test_use_amp.py
+++ b/test/test_use_amp.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from pymss.config import AttrDict
+from pymss.separator import MSSeparator
+from pymss.utils import _resolve_use_amp
+
+
+class CaptureLogger:
+    def __init__(self):
+        self.debug_messages = []
+        self.info_messages = []
+
+    def debug(self, message):
+        self.debug_messages.append(message)
+
+    def info(self, message):
+        self.info_messages.append(message)
+
+
+def _config(*, training_use_amp=True, inference_use_amp=None, include_inference_use_amp=True):
+    inference = {
+        "batch_size": 1,
+        "overlap_size": 0,
+    }
+    if include_inference_use_amp:
+        inference["use_amp"] = inference_use_amp
+    return AttrDict(
+        {
+            "training": {
+                "instruments": ["vocals", "other"],
+                "target_instrument": None,
+                "use_amp": training_use_amp,
+            },
+            "audio": {"chunk_size": 1024},
+            "inference": inference,
+        }
+    )
+
+
+def test_resolve_use_amp_prefers_inference_override():
+    assert _resolve_use_amp(_config(training_use_amp=True, inference_use_amp=False)) is False
+    assert _resolve_use_amp(_config(training_use_amp=False, inference_use_amp=True)) is True
+
+
+def test_resolve_use_amp_falls_back_to_training_config():
+    assert _resolve_use_amp(_config(training_use_amp=False, include_inference_use_amp=False)) is False
+    assert _resolve_use_amp(_config(training_use_amp=True, inference_use_amp=None)) is True
+
+
+def test_update_inference_params_controls_effective_amp():
+    config = _config(training_use_amp=True, inference_use_amp=True)
+    separator = SimpleNamespace(logger=CaptureLogger())
+
+    MSSeparator.update_inference_params(separator, config, {"use_amp": False})
+
+    assert config.inference["use_amp"] is False
+    assert config.training["use_amp"] is True
+    assert _resolve_use_amp(config) is False
+
+
+def test_mss_debug_log_prints_effective_amp():
+    logger = CaptureLogger()
+    separator = SimpleNamespace(
+        logger=logger,
+        model_path="model.ckpt",
+        store_dirs={},
+        save_as_folder=False,
+        output_format="wav",
+        audio_params={},
+        output_normalize=False,
+        use_tta=False,
+    )
+
+    MSSeparator._log_model_config(separator, "bs_roformer", _config(training_use_amp=True, inference_use_amp=False))
+
+    assert any("MSS model params: use_amp: False" in message for message in logger.debug_messages)


### PR DESCRIPTION
Fixes #16 

主要改动：

- 新增 _resolve_use_amp(config)。
- 优先使用 config.inference.use_amp。
- 未设置 inference.use_amp 时回退到 config.training.use_amp。
- 修复普通 MSS、HTDemucs、legacy Demucs/TasNet 三条推理路径。
- 让 MSS debug log 输出 effective use_amp。
- 增加 override 优先级、旧配置回退和日志输出的回归测试。